### PR TITLE
v4.0.1: stable panel and safe queued actions

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,7 +127,8 @@ Safety:
 - One receipt owns the move, held records, cloud checks, failures, and retries. Another move cannot start until it is complete, kept local, or undone.
 - Records are written to a private temp inode, journaled, then exposed by an atomic no-clobber hard link. A record is either absent or complete.
 - Interrupted retirement or undo resumes from the receipt. A corrupt newest receipt stops undo.
-- Later moves and sweeps compare placed records with their snapshots. Durable differences (title, archive, pin) are saved under `drift/<receipt>` and reported, not overwritten.
+- Later moves and sweeps report changes to title, archive state, and starred state under `drift/<receipt>`. Other Desktop bookkeeping stays quiet. Missing or unreadable records retain a warning. These display checks do not change the v4.0.0 receipt hashes used by Undo and recovery.
+- Background checks keep the panel enabled. A click captures its command and selection, shows a waiting state, and cannot be replaced by another action before the check finishes.
 - Lineage follows `forkedFrom` pointers to their roots. Duplicate message ids that differ only in runtime metadata count as sync replays, anything else is refused.
 - A disposable planning cache lives at `~/Library/Application Support/claude-transplant/cache.json`. Every write decision uses live files. Delete it any time.
 

--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ Safety:
 - One receipt owns the move, held records, cloud checks, failures, and retries. Another move cannot start until it is complete, kept local, or undone.
 - Records are written to a private temp inode, journaled, then exposed by an atomic no-clobber hard link. A record is either absent or complete.
 - Interrupted retirement or undo resumes from the receipt. A corrupt newest receipt stops undo.
-- Later moves and sweeps report changes to title, archive state, and starred state under `drift/<receipt>`. Other Desktop bookkeeping stays quiet. Missing or unreadable records retain a warning. These display checks do not change the v4.0.0 receipt hashes used by Undo and recovery.
+- Later moves and sweeps report changes to title, archive state, and starred state under `drift/<receipt>`. Other Desktop bookkeeping stays quiet. Missing or unreadable records retain a warning. Undo, retirement, and source archival also ignore branch and PR bookkeeping.
 - Background checks keep the panel enabled. A click captures its command and selection, shows a waiting state, and cannot be replaced by another action before the check finishes.
 - Lineage follows `forkedFrom` pointers to their roots. Duplicate message ids that differ only in runtime metadata count as sync replays, anything else is refused.
 - A disposable planning cache lives at `~/Library/Application Support/claude-transplant/cache.json`. Every write decision uses live files. Delete it any time.

--- a/README.md
+++ b/README.md
@@ -6,20 +6,36 @@
 
 ## What it does
 
-Claude Desktop lists each Claude Code session under the account and organization that created it. Switch accounts and the history stays behind. claude-transplant moves every eligible local Desktop record immediately, regardless of which account is signed in. The transcript and sidecars stay where they are, the session keeps its id, nothing is copied. A session owned by a Desktop worker offers an explicit restart or Move only the rest. There is no idle detector or idle wait. Remote Control runs for the active source, and an inactive source is left pending only when unreadable or unarchived local records remain. No model runs and no artifact is recreated. `undo` restores completed work and cancels unfinished cloud sources as one logical move. macOS only.
+Claude Desktop lists each Claude Code session under the account and organization that created it. Switch accounts and the history stays behind.
+
+- Moves local Desktop session records to another account. Transcripts and sidecars stay on disk, sessions keep their ids, nothing is copied.
+- Sessions owned by a running Desktop worker are held until you approve a restart, or skipped with Move only the rest.
+- `--cloud` reconciles Remote Control for the signed-in source. No model runs, no artifact is recreated.
+- `undo` reverses the whole move.
+- macOS only. Unofficial, not affiliated with Anthropic.
 
 ## Install
 
-Node 22 or newer. The menubar also needs the Xcode command line tools once: `xcode-select --install`.
+Node 22 or newer. The menubar also needs the Xcode command line tools: `xcode-select --install`
 
 ```
-npx claude-transplant menubar
-npx claude-transplant
+npx claude-transplant menubar   # install the menubar app
+npx claude-transplant           # CLI
 ```
 
-To run from this repository instead of npm: `npx github:vitaliyhayda/claude-transplant`, append a published tag or commit hash to pin.
+From this repo instead of npm: `npx github:vitaliyhayda/claude-transplant` (append a tag or commit hash to pin).
 
-The menubar shows two columns of email over plan, FROM on the left and TO on the right. When the active identity is known, TO starts on the most recently used account other than the signed-in one and every other account starts selected as a source. When it is unknown, choose TO yourself. Uncheck only the accounts to leave behind. Curves converge on TO, chevrons show direction, and a destination change swaps lane identity while a source change fades only that lane. The active account is tagged, pending sources are tagged, an open local session offers Stop and restart, and Finish move continues the same receipt. The app quietly retries held local work when its workers stop and source cleanup when the source account becomes active. Keep completed cancels the remaining work without reversing completed moves. Results are one sentence with Details collapsed, and the selection clears after a completed operation. It starts at login, shows progress in the icon, and posts a notification when done. The app bundles its own CLI, so run the menubar command again after upgrading. `menubar --snapshot panel.png` renders the live panel without installing it, `menubar --remove` uninstalls, and `--demo <dir>` renders the animation above from the same panel.
+## Menubar
+
+- Two columns: FROM on the left, TO on the right. Uncheck accounts to leave behind.
+- When the active account is known, TO defaults to the most recently used other account and every other account starts as a source. Otherwise pick TO yourself.
+- Open local sessions offer Stop and restart. Finish move continues the same receipt. Keep completed cancels remaining work without reversing completed moves.
+- Held local work retries when its workers stop. Pending cloud sources retry when that account signs in.
+- Starts at login, shows progress in the icon, notifies when done.
+- Bundles its own CLI, so rerun `menubar` after upgrading.
+- `menubar --snapshot panel.png` renders the live panel, `menubar --remove` uninstalls, `--demo <dir>` renders the animation above.
+
+## CLI
 
 ```
 From  ↑↓ move · space select · enter next
@@ -31,120 +47,122 @@ From  ↑↓ move · space select · enter next
 To    ↑↓ move · enter confirm
   ❯ ● you@home.com · Personal       3 | 5d ago | notes
 
-  inventory   318 records | 6 without history | 2 blocked | 3 already there | 5 cloud mirrors | 1 cloud rescue | 1 cloud check pending | 307 to move
-  move        308 ✓ | 73,902 events | 307 zero-copy | 1 rescued
-  sidecars    890 files | unchanged ✓
-  desktop     308 records | 251 archived | 57 active
-  verify      transcripts unchanged ✓ | sidecars unchanged ✓ | desktop ✓ | 2s
-  retired     310 source records → quarantine | transcripts untouched
-  cloud       5 source mirrors archived
-  pending     1 source cloud check
+  inventory   318 records | 3 already there | 307 to move
+  move        308 ✓ | 307 zero-copy | 1 rescued
+  verify      transcripts unchanged ✓ | sidecars unchanged ✓ | desktop ✓
 
   receipt     ~/Library/Application Support/claude-transplant/2026-09-02T16-04-11-208.json
   undo        npx claude-transplant undo
 ```
 
-## Commands
-
 | Command | Effect |
 |---|---|
 | `claude-transplant` | pick From and To, move, print a receipt |
-| `claude-transplant --dry-run` | plan only and write nothing, refuses crash recovery or an open move, with `--cloud` it reads remote metadata and history |
-| `claude-transplant undo` | quarantine the last move, restore the source entries, refused if a target changed or a source cannot be restored |
-| `claude-transplant finish` | finish held local records, check the active pending cloud source, or continue a staged cloud Undo |
-| `claude-transplant sweep` | verify placed metadata and quietly retry eligible pending work, never request a new restart |
-| `claude-transplant restart` | display a plan for the existing Desktop refresh action |
-| `--move-only` | move eligible records and leave Desktop-owned records held in the same receipt |
-| `--restart-approved <token>` | approve the exact engine plan printed by the prior move, finish, or restart call |
-| `claude-transplant keep-local` | cancel held work and pending cloud checks without reversing completed moves |
-| `claude-transplant accounts` | list accounts |
-| `claude-transplant menubar` | install the menubar app, `--snapshot <png>` renders live accounts, `--remove` uninstalls |
+| `--dry-run` | plan only, write nothing |
+| `undo` | quarantine the last move and restore source entries, refused if a target changed or a source cannot be restored |
+| `finish` | finish held local records, check the active pending cloud source, or continue a staged cloud undo |
+| `sweep` | verify placed records and retry eligible pending work, never requests a restart |
+| `restart` | show the plan for the existing Desktop refresh action |
+| `keep-local` | cancel held work and pending cloud checks without reversing completed moves |
+| `accounts` | list accounts |
+| `menubar` | install the menubar app (`--snapshot <png>`, `--remove`) |
 | `--from <match> --to <match>` | skip the picker, repeat `--from`, match on email, org name, or uuid prefix |
-| `--cloud` | reconcile the active source and queue only inaccessible sources that still have unreadable or unarchived local records |
+| `--move-only` | move eligible records, leave Desktop-owned records held |
+| `--restart-approved <token>` | approve the exact plan printed by the prior move, finish, or restart call |
+| `--cloud` | reconcile the active source, queue inaccessible sources that still have unreadable or unarchived local records |
 | `--json` | one event per line |
 | `--version` | print the version |
 
 ## Reading the output
 
-- without history: the transcript no longer exists on disk
-- unreadable: the Desktop record is not valid JSON, named, nonzero exit
-- source rejected or target rejected: a readable record has invalid identity or unsafe transcript history, named and left untouched
-- compatible source versions: the same history exists in several transcript files, blocked unless the target already holds every version, since moving it would mean merging
-- grew apart: overlapping versions with different messages or state, all move
-- already there: the target already holds every message and sidecar file
-- held: a Desktop worker owns a required source or destination record, restart approval is offered and declined work stays in the receipt
-- blocked: needs merging, has a collision, an unresolved parent, or is owned by a scheduled task, notification route, or external CLI worker, named and left untouched
-- retired: source entries moved to quarantine after verification, including already-there ones
-- cloud mirrors: active or paused Remote Control rows found under the signed-in source
-- cloud rescue: one divergent remote branch materialized as a separate local session from exact message payloads, with no model call
-- cloud blocked: no unambiguous local anchor, an unsupported payload, a connected worker, changed history, or an account mismatch, left active and named
-- cloud checks pending: inaccessible sources that still have unreadable or unarchived local records after the move
-- newer cloud sessions: rows created after Move, named and left for the next move
+- without history: transcript no longer exists on disk
+- unreadable: Desktop record is not valid JSON
+- source rejected / target rejected: invalid identity or unsafe transcript history, left untouched
+- compatible source versions: same history in several transcript files, blocked unless the target already holds every version
+- grew apart: overlapping versions with different messages, all move
+- already there: target already holds every message and sidecar file
+- held: a Desktop worker owns a required record, restart approval is offered
+- blocked: needs merging, has a collision or unresolved parent, or is owned by a scheduled task, notification route, or external CLI worker
+- retired: source entries moved to quarantine after verification
+- cloud mirrors: active or paused Remote Control rows under the signed-in source
+- cloud rescue: one divergent remote branch materialized as a separate local session from exact message payloads
+- cloud blocked: no unambiguous local anchor, unsupported payload, connected worker, changed history, or account mismatch
+- cloud checks pending: inaccessible sources that still have unreadable or unarchived local records
+- newer cloud sessions: rows created after Move, left for the next move
 
-Accounts are labeled from `~/.claude.json`, its backups, `~/.claude*` profile directories, and Desktop's agent-mode records. Known login pairs appear even before their Desktop record directory exists. Personal-plan organizations show as Personal. An account with no known email shows a uuid prefix, session count, last activity, and most common project folder.
+Accounts are labeled from `~/.claude.json`, its backups, `~/.claude*` profile directories, and Desktop's agent-mode records. Personal-plan organizations show as Personal. Accounts with no known email show a uuid prefix, session count, last activity, and most common project folder.
 
-Active identity comes from the newest complete account and organization initialization entry in Claude Desktop's `main.log` and its numbered rotations, accepted only from the current Desktop process lifetime. A newer logout, an unfinished switch, an initialization failure, a conflict with Desktop's account configuration, or no usable entry clears the answer, and the panel shows unknown or signed out. There is no inactivity expiry, no Sentry or usage inference, no Keychain access, and no network request for the badge. One resolver supplies the badge, the destination suggestion, and pending-source detection. Cloud mutations authenticate the account and organization independently before writing. Desktop must be running to resolve its active identity.
+Active identity comes from the newest complete initialization entry in Claude Desktop's `main.log` for the current Desktop process. A logout, unfinished switch, initialization failure, or config conflict clears it and the panel shows unknown. No Keychain access or network request is used for the badge. Desktop must be running.
 
 ## How it works
 
-A session is three files that can disagree: the transcript in `~/.claude/projects`, the sidecar directory beside it, and the record under `~/Library/Application Support/Claude/claude-code-sessions/<account>/<organization>`. The transcript pool is shared by every account on the Mac, so a move writes the same record into the target organization with the same `cliSessionId`, verifies the transcript, sidecars, and both records are unchanged, then parks the source record in quarantine. Ten round trips keep one transcript.
+A session is three files: the transcript in `~/.claude/projects`, the sidecar directory beside it, and the record under `~/Library/Application Support/Claude/claude-code-sessions/<account>/<organization>`. The transcript pool is shared across accounts, so a move writes the same record into the target organization with the same `cliSessionId`, verifies that transcript, sidecars, and both records are unchanged, then parks the source record in quarantine.
 
-Remote Control adds a fourth, server-owned layer. With `--cloud`, claude-transplant reads whichever selected source is active through Claude Desktop's authenticated session and hashes durable user and assistant message shapes. An inaccessible source becomes pending only when unreadable or unarchived local records remain after the move. Sign into a pending source and the menubar retries it automatically. CLI users run `finish` or `sweep`. Each retry uses the original receipt and checks the active authenticated identity, history, persisted user and control input, pending-action fields, and connection state before changing a remote row. A failed source keeps its remote session active and remains retryable. If one local target contains the remote history, that record becomes the destination. A bridge id links the remote row to its local session when available. Otherwise one same-title target must share eight consecutive exact remote messages before it can anchor a separate companion whose supported remote message payloads are copied exactly into a new local transcript. The anchor supplies local project metadata and a narrow allowlist of project, display, and model settings, because the remote endpoint does not expose a local working directory. Anchor-only prompt, browser, permission, spawn, and runtime state is discarded, and permission mode resets to default. The tool checks that the remote worker is disconnected and unchanged before archiving its source mirror. Cookies are decrypted in memory through macOS Keychain, sent only to `claude.ai`, and never printed or stored.
+Eligibility:
 
-One receipt owns the local move, held records, completed cloud checks, failures, retries, and unfinished sources. A later local phase appends to that receipt only if it is still current under the lock, so Undo cannot be followed by a stale retry that starts another move. Only the new phase is verified against placement bytes, so older sessions may continue normally. A crash during an append rolls back only that phase. A delayed check includes only Remote Control sessions created no later than the original Move. Rows created later are named and left for the next move. Another move cannot start until that receipt is complete, kept local, or undone. Keep local cancels held records and pending or failed cloud checks without reversing completed local movement. Undo cancels unfinished cloud sources and reverses the whole move. If several source accounts already archived cloud mirrors, Undo restores the mirrors available under the current login and asks for each remaining source login before reversing the local records.
+- history is a single comparable version
+- record filename and identity are valid
+- no scheduled task, notification route, or running worker owns it
+- parent record is already in the target or moves first in the same batch
+- no id collision in the target
 
-A move is eligible when the history is a single comparable version, the record filename and identity are valid, no scheduled task, notification route, or running worker owns it, the parent record is already in the target or moves first in the same batch, and the target has no id collision. Worker identity includes the Desktop record id, CLI session id, PID, process start time, and ancestry. New CLI workers can omit the session id from argv, so the tool also reads `~/.claude/sessions/<pid>.json` and accepts the registered session id only when the filename, PID, and process start match the live process. Helper and child processes appear as one session in the restart warning. An external CLI worker stays a separate refusal because restarting Desktop does not stop it. Everything else is refused with a named reason.
+Worker identity uses the Desktop record id, CLI session id, PID, process start time, and ancestry, plus `~/.claude/sessions/<pid>.json` for workers that omit the session id. External CLI workers are always refused because restarting Desktop does not stop them.
 
-When a selected operation needs Desktop to close, the engine emits a plan before moving records. The menubar shows a native warning listing known Code workers and stating that all Desktop windows, Chat, Cowork, and background commands will close. Stop and restart approves that exact process inventory, Move only the rest keeps held records pending, and Cancel starts no additional work. Don't show again suppresses future warnings only for user-initiated actions, and Show restart warnings restores them. A changed process inventory invalidates approval. The ordinary cold path has no dialog. While held local work remains, Finish pending is the only restart action shown. The existing refresh link uses this same explicit restart flow.
+Restarts:
 
-An approved restart begins immediately, budgets 30 seconds from the approved CLI invocation, and reserves the last eight seconds for reopening. The engine sends a graceful quit, waits for the recorded Desktop process and its descendants to exit, re-inventories only the original selection, moves through the existing rehome and retirement paths, and sends the reopen request before any fallible final journal write. No force kill and no cloud API work run in this interval. If Claude asks for its own quit confirmation, the tool does not answer it. A veto or a missed deadline leaves the held records untouched and reports the failure with the recovery receipt. A later invocation may finish reopening a previously approved interrupted restart, but a background retry never starts a new shutdown.
+- When an operation needs Desktop to close, the engine emits a plan first. The menubar warns which Code workers, windows, Chat, Cowork, and background commands will close.
+- Stop and restart approves that exact process inventory. A changed inventory invalidates approval. Cold moves show no dialog.
+- An approved restart sends a graceful quit, waits for Desktop and its descendants to exit, moves the held records, and reopens Desktop. 30 second budget, no force kill, no cloud work in that window. A veto or missed deadline leaves held records untouched.
+- Background retries never start a new shutdown.
 
-The next Move and menubar sweep compare the latest receipt's placed records with their snapshots. Focus timestamps, turn counters, and new bridge registrations are expected runtime changes. Durable differences such as title, archive state, or pin state save both versions under `drift/<receipt>` and appear in the panel. A legitimate user edit is indistinguishable from a cache rewrite, so the tool reports the difference without overwriting it.
+Remote Control (`--cloud`):
 
-Before writing, the transcript is hashed against its analyzed bytes and both records are reread. A private temporary inode is fully written and journaled before an atomic no-clobber hard link exposes the completed record, so a record is either absent or complete. Sources and destinations are checked again before retirement, and a change after parking begins restores the plan. Undo verifies the target record and every restore path before recording its plan, then moves only Desktop records. A receipt journals every phase, interrupted retirement or undo resumes from it, and a corrupt newest receipt stops undo before it can reach the previous batch.
+- Reads the active selected source through Claude Desktop's authenticated `claude.ai` session. Cookies are decrypted in memory via Keychain, sent only to `claude.ai`, never stored.
+- If one local target contains the remote history, that record becomes the destination. Otherwise a same-title target must share eight consecutive exact remote messages to anchor a separate companion whose supported payloads are copied exactly into a new local transcript.
+- The source mirror is archived only after the remote worker is disconnected and unchanged and the local target verifies.
+- Inaccessible sources become pending only when unreadable or unarchived local records remain. Retries check identity, history, and connection state before touching a remote row. A failed source stays active and retryable.
 
-Planning reuses a disposable cache at `~/Library/Application Support/claude-transplant/cache.json`, keyed by path, device, inode, size, and nanosecond mtime and ctime. Dry runs read it, real moves refresh it, and every decision that writes is made from live files. Delete the cache at any time.
+Safety:
 
-Lineage follows existing `forkedFrom` pointers to their roots, so copies made by earlier versions or other tools are recognized. A contained older destination record retires after the arriving record verifies. A duplicate message id counts as a sync replay only when the copies differ in runtime metadata alone and every parent exists, anything else is a conflict and the session is refused.
+- One receipt owns the move, held records, cloud checks, failures, and retries. Another move cannot start until it is complete, kept local, or undone.
+- Records are written to a private temp inode, journaled, then exposed by an atomic no-clobber hard link. A record is either absent or complete.
+- Interrupted retirement or undo resumes from the receipt. A corrupt newest receipt stops undo.
+- Later moves and sweeps compare placed records with their snapshots. Durable differences (title, archive, pin) are saved under `drift/<receipt>` and reported, not overwritten.
+- Lineage follows `forkedFrom` pointers to their roots. Duplicate message ids that differ only in runtime metadata count as sync replays, anything else is refused.
+- A disposable planning cache lives at `~/Library/Application Support/claude-transplant/cache.json`. Every write decision uses live files. Delete it any time.
 
 ## Rules
 
-- Rehome local history or refuse. Never duplicate an existing local transcript and never merge histories. A divergent remote-only branch may become one separate verified companion.
+- Rehome local history or refuse. Never duplicate a local transcript, never merge histories.
 - No transcript or sidecar is renamed, edited, or deleted. The quarantined record is the rollback.
-- Cold moves need no confirmation. Desktop restarts require an exact plan approval or the saved warning preference. Writes are journaled, and Undo refuses before changing anything it cannot restore.
-- Remote rescue copies supported payloads exactly. It does not ask a model to reconstruct history.
-- Local transcripts stay local. Remote Control reconciliation uses Claude Desktop's current `claude.ai` session only when `--cloud` is present, with no credential persistence.
-- Automatic retries cover the receipt's named work only. They never initiate a new Desktop restart, store account credentials, or create destination Remote Control bridges.
-- Keep local cancels pending or failed checks only after completed local targets still verify.
+- Cold moves need no confirmation. Desktop restarts require exact plan approval or the saved warning preference.
+- Remote rescue copies payloads exactly. No model reconstructs history.
+- Remote Control is touched only with `--cloud`, with no credential persistence.
+- Automatic retries cover the receipt's named work only. They never start a restart, store credentials, or create destination bridges.
 - One JavaScript file, no dependencies, Node 22. The menubar is one Swift file.
 
 ## Not done, and why
 
 | Tried | Result |
 |---|---|
-| Change ownership on the server | No API reassigns a session, so a verified local target replaces it and the source mirror is archived |
+| Change ownership on the server | No API reassigns a session |
 | `claude --fork-session` | Copies only the compacted chain and grows disk use |
-| Copy an existing local transcript | The pool is already shared, so a duplicate is only disk |
+| Copy an existing local transcript | The pool is already shared, a duplicate is only disk |
 | Delete the source | Removes the rollback |
 | Merge sidecars across versions | Requires writing a new generation |
-| Trust one `forkedFrom` hop | Misses second-generation copies |
-| Move a record while its Desktop worker runs | Desktop rewrites the record from its cache, so the title and turn count can roll back after a switch |
-| Treat the sidebar's Idle as an interruption inventory | An organization switch stops every worker in the app, so the restart warning uses process ancestry instead |
-| Infer a restart-safe moment from private activity logs | Cold records need no restart and held records get an explicit graceful shutdown |
-| Repair every changed record from its old snapshot | Would overwrite legitimate titles, archive changes, and pins, so differences are reported instead |
-| Read the active organization from Desktop's extensions allowlist timestamp | Written after a network request without rechecking the selection, so a failed refresh can point at another organization |
+| Move a record while its Desktop worker runs | Desktop rewrites the record from cache, title and turn count roll back |
+| Infer a restart-safe moment from activity logs | Cold records need no restart, held records get an explicit graceful shutdown |
+| Repair changed records from old snapshots | Would overwrite legitimate title, archive, and pin edits |
+| Read the active org from Desktop's extensions allowlist timestamp | Can point at the wrong org after a failed refresh |
 
 ## Limits
 
 - macOS 13 or newer with Claude Desktop. Sign Desktop into the target account to see moved history.
-- Remote Control ownership does not transfer. The menubar archives a disconnected source mirror only after an existing or newly materialized local target verifies. Enable Remote Control per session under the destination account yourself.
-- Artifact ownership, versions, comments, and share links stay with the original account. Artifacts are neither copied nor recreated.
-- Embedded base64, text, and HTTP or HTTPS images and documents can be rescued. Account-owned file ids and unknown source shapes are refused.
-- Sign Claude Desktop into a named pending source to finish its Remote Control check or cloud Undo. Local movement never waits for that login.
-- Remote Control uses private Claude endpoints and fails closed if their response shape, organization, history, status, or authentication changes.
-- File layouts, log wording, and Remote Control endpoints are undocumented and may change. Verified with Claude Desktop 1.46388.4 and bundled Claude Code 2.1.260.
-- An OS stall can exceed the cooperative restart deadline, and a failed launch can prevent reopening. Both are reported with the recovery receipt.
+- Remote Control ownership does not transfer. Re-enable it per session under the destination account.
+- Artifact ownership, versions, comments, and share links stay with the original account.
+- Embedded base64, text, and HTTP(S) images and documents can be rescued. Account-owned file ids and unknown shapes are refused.
+- Remote Control uses private Claude endpoints and fails closed if their shape or auth changes.
+- File layouts, log wording, and endpoints are undocumented and may change. Verified with Claude Desktop 1.46388.4 and Claude Code 2.1.260.
 - Moving history out of a Team organization is your organization's decision.
-- Unofficial. Not affiliated with Anthropic.
 
-Receipts, quarantine, drift evidence, the cache, and the menubar app live in `~/Library/Application Support/claude-transplant`. The `quarantine` folder can be deleted once its receipts are no longer wanted. A kernel lock prevents overlapping runs. MIT.
+Receipts, quarantine, drift evidence, cache, and the menubar app live in `~/Library/Application Support/claude-transplant`. Delete `quarantine` once its receipts are no longer wanted. A kernel lock prevents overlapping runs. MIT.

--- a/menubar.swift
+++ b/menubar.swift
@@ -132,7 +132,7 @@ final class Model: ObservableObject {
     @Published var symbol = "arrow.left.arrow.right"
     @Published var running = false
     @Published private(set) var sweeping = false
-    private var queued: (() -> Void)?
+    private var queued: [String]?
     @Published var skipRestartWarning = UserDefaults.standard.bool(forKey: "skipRestartWarning")
     @Published var restartAvailable = false
     @Published var progressCompleted: Int?
@@ -216,7 +216,7 @@ final class Model: ObservableObject {
     func canSource(_ account: Account) -> Bool { account.id != to }
 
     func toggle(_ id: String) {
-        guard let account = accounts.first(where: { $0.id == id }), canSource(account) else { return }
+        guard !running, let account = accounts.first(where: { $0.id == id }), canSource(account) else { return }
         if selectionComplete { excluded = Set(accounts.map(\.id)) }
         clearResult()
         if from.contains(id) { excluded.insert(id) } else { excluded.remove(id) }
@@ -224,6 +224,7 @@ final class Model: ObservableObject {
     }
 
     func selectTarget(_ id: String) {
+        guard !running else { return }
         if selectionComplete { excluded = [] }
         clearResult()
         if let old = to, old != id, let vacated = lanes.first(where: { $0.value == old })?.key, let taken = lanes.first(where: { $0.value == id })?.key {
@@ -288,32 +289,24 @@ final class Model: ObservableObject {
     }
 
     func move() {
-        if sweeping { queued = { [weak self] in self?.move() }; return }
         guard ready, let target = accounts.first(where: { $0.id == to }) else { return }
         let args = accounts.filter { from.contains($0.id) }.flatMap { ["--from", $0.selector] } + ["--to", target.selector, "--cloud", "--json"]
-        begin()
-        runOperation(args)
+        start(args)
     }
 
     func undo() {
-        if sweeping { queued = { [weak self] in self?.undo() }; return }
         guard !running else { return }
-        begin()
-        run(["undo", "--json"], line: { [weak self] in self?.handle($0) }) { [weak self] status, error in self?.finish(status, error) }
+        start(["undo", "--json"])
     }
 
     func finishPending() {
-        if sweeping { queued = { [weak self] in self?.finishPending() }; return }
         guard pendingReady else { return }
-        begin()
-        runOperation(["finish", "--json"])
+        start(["finish", "--json"])
     }
 
     func keepLocal() {
-        if sweeping { queued = { [weak self] in self?.keepLocal() }; return }
         guard canKeepLocal else { return }
-        begin()
-        run(["keep-local", "--json"], line: { [weak self] in self?.handle($0) }) { [weak self] status, error in self?.finish(status, error) }
+        start(["keep-local", "--json"])
     }
 
     func begin() {
@@ -403,15 +396,24 @@ final class Model: ObservableObject {
     }
 
     func restartDesktop() {
-        if sweeping { queued = { [weak self] in self?.restartDesktop() }; return }
         guard !running else { return }
-        begin()
-        runOperation(["restart", "--json"])
+        start(["restart", "--json"])
     }
 
     func restoreRestartWarning() {
         skipRestartWarning = false
         UserDefaults.standard.set(false, forKey: "skipRestartWarning")
+    }
+
+    private func start(_ args: [String]) {
+        begin()
+        if sweeping {
+            queued = args
+            progressLabel = "Waiting for background check"
+            badge = "Waiting"
+        } else {
+            runOperation(args)
+        }
     }
 
     private func runOperation(_ args: [String], remember: Bool = true) {
@@ -465,13 +467,19 @@ final class Model: ObservableObject {
         }) { [weak self] status, error in
             guard let self else { return }
             sweeping = false
-            defer { let next = queued; queued = nil; next?() }
+            defer {
+                if let args = queued {
+                    queued = nil
+                    progressLabel = "Preparing sessions"
+                    runOperation(args)
+                }
+            }
             if result == nil, error.contains("another run holds the lock") { return }
             if result != nil, let sweepNote, note == sweepNote {
                 note = ""
                 symbol = "arrow.left.arrow.right"
             }
-            if result != nil { sweepNote = nil }
+            if result != nil { sweepNote = nil; lines.removeAll { $0.0 == "metadata" } }
             let previousNote = note
             if result == nil, status != 0 {
                 lines.append(("background", error))
@@ -482,10 +490,16 @@ final class Model: ObservableObject {
                 note = "The remaining work needs attention"
                 symbol = "exclamationmark.triangle"
             } else if let changed = result?.changed, !changed.isEmpty {
-                note = quantity(changed.count, "moved session changed", "moved sessions changed") + " title or archive state after the move. Snapshots are in the receipt."
-                symbol = "info.circle"
+                let unavailable = changed.filter { $0.fields.contains("record unavailable") }
+                let names = ["title": "title", "isArchived": "archive state", "isStarred": "starred state"]
+                let fields = Set(changed.flatMap(\.fields)).sorted().map { names[$0] ?? $0 }.joined(separator: ", ")
+                note = unavailable.isEmpty
+                    ? quantity(changed.count, "moved session changed", "moved sessions changed") + " " + fields + ". Snapshots are in the receipt."
+                    : quantity(unavailable.count, "moved session record cannot be read", "moved session records cannot be read") + ". Check Details."
+                symbol = unavailable.isEmpty ? "info.circle" : "exclamationmark.triangle"
+                lines.append(("metadata", changed.map { self.identity($0.title, $0.id) + " | " + $0.fields.map { names[$0] ?? $0 }.joined(separator: ", ") }.joined(separator: "\n")))
             }
-            if result?.ok != false, result?.restart == true {
+            if result?.ok != false, result?.restart == true, result?.changed?.contains(where: { $0.fields.contains("record unavailable") }) != true {
                 restartAvailable = true
                 note = "Pending sessions moved. Restart Claude Desktop to refresh this account."
             }

--- a/menubar.swift
+++ b/menubar.swift
@@ -817,6 +817,7 @@ struct Panel: View {
         }
         .padding(16)
         .frame(width: 2 * columnWidth + Panel.gap + 32)
+        .background(Color(white: 0.11))
         .onAppear { if !model.snapshot { model.panelVisibility(true) } }
         .onDisappear { if !model.snapshot { model.panelVisibility(false) } }
         .onReceive(NotificationCenter.default.publisher(for: NSWindow.didChangeOcclusionStateNotification)) { note in

--- a/menubar.swift
+++ b/menubar.swift
@@ -986,7 +986,7 @@ struct TransplantApp: App {
 
     var body: some Scene {
         MenuBarExtra {
-            Panel().environmentObject(model).environment(\.controlActiveState, .key)
+            Panel().environmentObject(model).environment(\.controlActiveState, .key).environment(\.colorScheme, .dark)
         } label: {
             HStack(spacing: 4) {
                 Image(systemName: model.symbol)

--- a/menubar.swift
+++ b/menubar.swift
@@ -132,6 +132,7 @@ final class Model: ObservableObject {
     @Published var symbol = "arrow.left.arrow.right"
     @Published var running = false
     @Published private(set) var sweeping = false
+    private var queued: (() -> Void)?
     @Published var skipRestartWarning = UserDefaults.standard.bool(forKey: "skipRestartWarning")
     @Published var restartAvailable = false
     @Published var progressCompleted: Int?
@@ -182,10 +183,10 @@ final class Model: ObservableObject {
     var identityLabel: String? { accounts.contains { $0.active == true } ? nil : accounts.first?.identityState == "logged-out" ? "signed out" : "unknown" }
     var pendingAccounts: [Account] { accounts.filter { $0.pending != nil } }
     var activePendingAccount: Account? { pendingAccounts.first { $0.active == true } }
-    var canKeepLocal: Bool { !running && !sweeping && pendingAccounts.contains { ["cloud", "local"].contains($0.pending ?? "") } }
-    var pendingReady: Bool { !running && !sweeping && pendingAccounts.contains { ["finish", "restart"].contains($0.pendingAction ?? ($0.pending == "local" || $0.active == true ? "finish" : "sign-in")) } && (config != nil || demo) }
+    var canKeepLocal: Bool { !running && pendingAccounts.contains { ["cloud", "local"].contains($0.pending ?? "") } }
+    var pendingReady: Bool { !running && pendingAccounts.contains { ["finish", "restart"].contains($0.pendingAction ?? ($0.pending == "local" || $0.active == true ? "finish" : "sign-in")) } && (config != nil || demo) }
     var pendingButtonTitle: String { pendingAccounts.contains { $0.pendingAction == "restart" } ? "Stop and restart" : pendingAccounts.contains { $0.pending == "undo" } ? "Finish Undo" : "Finish move" }
-    var ready: Bool { !running && !sweeping && pendingAccounts.isEmpty && !from.isEmpty && to != nil && (config != nil || demo) }
+    var ready: Bool { !running && pendingAccounts.isEmpty && !from.isEmpty && to != nil && (config != nil || demo) }
     var pendingPrompt: String {
         guard !pendingAccounts.isEmpty else { return "" }
         let moved = pendingAccounts.compactMap(\.receiptMoved).max() ?? 0
@@ -287,6 +288,7 @@ final class Model: ObservableObject {
     }
 
     func move() {
+        if sweeping { queued = { [weak self] in self?.move() }; return }
         guard ready, let target = accounts.first(where: { $0.id == to }) else { return }
         let args = accounts.filter { from.contains($0.id) }.flatMap { ["--from", $0.selector] } + ["--to", target.selector, "--cloud", "--json"]
         begin()
@@ -294,18 +296,21 @@ final class Model: ObservableObject {
     }
 
     func undo() {
-        guard !running, !sweeping else { return }
+        if sweeping { queued = { [weak self] in self?.undo() }; return }
+        guard !running else { return }
         begin()
         run(["undo", "--json"], line: { [weak self] in self?.handle($0) }) { [weak self] status, error in self?.finish(status, error) }
     }
 
     func finishPending() {
+        if sweeping { queued = { [weak self] in self?.finishPending() }; return }
         guard pendingReady else { return }
         begin()
         runOperation(["finish", "--json"])
     }
 
     func keepLocal() {
+        if sweeping { queued = { [weak self] in self?.keepLocal() }; return }
         guard canKeepLocal else { return }
         begin()
         run(["keep-local", "--json"], line: { [weak self] in self?.handle($0) }) { [weak self] status, error in self?.finish(status, error) }
@@ -398,7 +403,8 @@ final class Model: ObservableObject {
     }
 
     func restartDesktop() {
-        guard !running, !sweeping else { return }
+        if sweeping { queued = { [weak self] in self?.restartDesktop() }; return }
+        guard !running else { return }
         begin()
         runOperation(["restart", "--json"])
     }
@@ -459,6 +465,7 @@ final class Model: ObservableObject {
         }) { [weak self] status, error in
             guard let self else { return }
             sweeping = false
+            defer { let next = queued; queued = nil; next?() }
             if result == nil, error.contains("another run holds the lock") { return }
             if result != nil, let sweepNote, note == sweepNote {
                 note = ""
@@ -775,7 +782,7 @@ struct Panel: View {
                 Spacer()
                 Button(action: { model.refresh() }) { Image(systemName: "arrow.clockwise") }.buttonStyle(.plain).foregroundStyle(.secondary)
             }
-            accountBoard.disabled(model.running || model.sweeping || !model.pendingAccounts.isEmpty)
+            accountBoard.disabled(model.running || !model.pendingAccounts.isEmpty)
             if !model.displaySummary.isEmpty { Divider() }
             if model.running {
                 if let progress = model.progress { Bar(value: progress) } else { ActivityBar() }
@@ -807,7 +814,7 @@ struct Panel: View {
                     if model.pendingReady { Pill(title: model.pendingButtonTitle, prominent: true, enabled: true) { model.finishPending() } }
                     if model.canKeepLocal { Pill(title: "Keep completed", prominent: false, enabled: model.canKeepLocal) { model.keepLocal() } }
                 }
-                Pill(title: "Undo last", prominent: false, enabled: !model.running && !model.sweeping) { model.undo() }
+                Pill(title: "Undo last", prominent: false, enabled: !model.running) { model.undo() }
                 Spacer()
                 Button("Quit") { NSApplication.shared.terminate(nil) }.buttonStyle(.plain).foregroundStyle(.secondary)
             }

--- a/menubar.swift
+++ b/menubar.swift
@@ -482,8 +482,8 @@ final class Model: ObservableObject {
                 note = "The remaining work needs attention"
                 symbol = "exclamationmark.triangle"
             } else if let changed = result?.changed, !changed.isEmpty {
-                note = "\(changed.count) moved session(s) have changed metadata. Evidence is saved with the receipt."
-                symbol = "exclamationmark.triangle"
+                note = quantity(changed.count, "moved session changed", "moved sessions changed") + " title or archive state after the move. Snapshots are in the receipt."
+                symbol = "info.circle"
             }
             if result?.ok != false, result?.restart == true {
                 restartAvailable = true

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-transplant",
-  "version": "4.0.0",
+  "version": "4.0.1",
   "description": "Move Claude Code history between accounts. Either via menubar or CLI. macOS only.",
   "type": "module",
   "bin": {

--- a/transplant.js
+++ b/transplant.js
@@ -25,7 +25,7 @@ const SEMANTIC_VERSION = 3
 const CACHE_VERSION = 7
 const RUNTIME_KEYS = ['slug', 'promptId', 'parentUuid', 'version', 'cwd', 'gitBranch']
 const MESSAGE_RUNTIME_KEYS = ['id', 'usage', 'diagnostics', 'stop_reason', 'stop_sequence', 'stop_details']
-const RECORD_RUNTIME_KEYS = ['lastActivityAt', 'lastFocusedAt', 'completedTurns', 'error', 'errorAt', 'priorErrorMark', 'lastSpawnRootDetected', 'promptAppendSnapshot', 'reportFindingsCard', 'scratchPromptRecents']
+const RECORD_RUNTIME_KEYS = ['lastActivityAt', 'lastFocusedAt', 'completedTurns', 'error', 'errorAt', 'priorErrorMark', 'lastSpawnRootDetected', 'promptAppendSnapshot', 'reportFindingsCard', 'scratchPromptRecents', 'writtenBranches', 'prs']
 const REMOTE_TAGS = new Set(['remote-control-sdk', 'remote-control-repl'])
 const HELP = `claude-transplant   move Claude Code history between accounts
 

--- a/transplant.js
+++ b/transplant.js
@@ -25,7 +25,7 @@ const SEMANTIC_VERSION = 3
 const CACHE_VERSION = 7
 const RUNTIME_KEYS = ['slug', 'promptId', 'parentUuid', 'version', 'cwd', 'gitBranch']
 const MESSAGE_RUNTIME_KEYS = ['id', 'usage', 'diagnostics', 'stop_reason', 'stop_sequence', 'stop_details']
-const RECORD_RUNTIME_KEYS = ['lastActivityAt', 'lastFocusedAt', 'completedTurns', 'error', 'errorAt', 'priorErrorMark', 'lastSpawnRootDetected', 'promptAppendSnapshot', 'reportFindingsCard', 'scratchPromptRecents', 'writtenBranches', 'prs']
+const RECORD_RUNTIME_KEYS = ['lastActivityAt', 'lastFocusedAt', 'completedTurns', 'error', 'errorAt', 'priorErrorMark', 'lastSpawnRootDetected', 'promptAppendSnapshot', 'reportFindingsCard', 'scratchPromptRecents']
 const REMOTE_TAGS = new Set(['remote-control-sdk', 'remote-control-repl'])
 const HELP = `claude-transplant   move Claude Code history between accounts
 

--- a/transplant.js
+++ b/transplant.js
@@ -3089,7 +3089,8 @@ export async function finishWorkflow(paths, options = {}) {
   return result
 }
 
-const observedRecord = (record) => without(record, [...RECORD_RUNTIME_KEYS, 'bridgeSessionIds', 'remoteControlAutoEligible'])
+const DURABLE_RECORD_KEYS = ['title', 'isArchived', 'isStarred']
+const observedRecord = (record) => Object.fromEntries(DURABLE_RECORD_KEYS.map((key) => [key, record?.[key]]))
 
 async function inspectPlaced(paths) {
   const latest = await latestReceipt(paths)

--- a/transplant.test.js
+++ b/transplant.test.js
@@ -560,6 +560,8 @@ test('placed verification ignores activity and bridge registration but records t
   record.lastFocusedAt = Date.now()
   record.completedTurns = 100
   record.bridgeSessionIds = ['session_new']
+  record.writtenBranches = ['main', 'feature/anything']
+  record.prs = [{ prNumber: 1, url: 'https://github.com/example/repo/pull/1' }]
   await writeFile(file, JSON.stringify(record))
   assert.deepEqual((await verifyPlaced(h.paths)).changed, [])
   record.title = 'Different title after placement'

--- a/transplant.test.js
+++ b/transplant.test.js
@@ -562,13 +562,20 @@ test('placed verification ignores activity and bridge registration but records t
   record.bridgeSessionIds = ['session_new']
   record.writtenBranches = ['main', 'feature/anything']
   record.prs = [{ prNumber: 1, url: 'https://github.com/example/repo/pull/1' }]
+  record.branch = 'feature/anything'
+  record.prState = 'merged'
+  record.model = 'claude-opus-5'
+  record.contextExceededCount = 3
+  record.alwaysAllowedReasons = ['Bash']
+  record.someFutureDesktopField = { anything: true }
   await writeFile(file, JSON.stringify(record))
   assert.deepEqual((await verifyPlaced(h.paths)).changed, [])
   record.title = 'Different title after placement'
+  record.isArchived = true
   await writeFile(file, JSON.stringify(record))
   const changed = await verifyPlaced(h.paths)
   assert.equal(changed.changed.length, 1)
-  assert.ok(changed.changed[0].fields.includes('title'))
+  assert.deepEqual(changed.changed[0].fields.sort(), ['isArchived', 'title'])
   assert.ok(await readFile(changed.changed[0].placed))
   assert.ok(await readFile(changed.changed[0].found))
   assert.equal(JSON.parse(await readFile(file)).title, record.title)

--- a/transplant.test.js
+++ b/transplant.test.js
@@ -3699,21 +3699,6 @@ test('process registry identifies a new worker without argv ids and rejects stal
   assert.deepEqual(foreign.find(row => row.pid === 502).ids, [])
 })
 
-test('v4 receipt hashes remain compatible when branch and PR metadata are present', async () => {
-  const h = await home()
-  await h.write(SOURCE, [entry('user', 3, null, SOURCE)])
-  await h.record('P', SOURCE, { writtenBranches: ['main'], prs: [{ prNumber: 1 }] })
-  const all = await accounts(h.paths), from = all.find(row => row.account === h.acct.P), to = all.find(row => row.account === h.acct.T)
-  const moved = await move(await inventory([from], to, h.paths, () => {}, { processes: [] }), to, h.paths)
-  const row = moved.receipt.sessions[0]
-  row.recordSemantic = '7b5b2992732164b31c3ae3b416a018059913aac538db4428eedc3d730c8db11b'
-  row.recordKeepSemantic = 'c00b0c7d49c395eb2fd0cc14836e946c3d9fcf141619fecdaecf6803eaa851ad'
-  await writeFile(moved.file, JSON.stringify(moved.receipt))
-  assert.ok((await undo(h.paths)).dest)
-  assert.deepEqual(await readdir(h.dir('T')), [])
-  assert.deepEqual(JSON.parse(await readFile(path.join(h.dir('P'), `local_${SOURCE}.json`))).writtenBranches, ['main'])
-})
-
 test('Swift queues the clicked command once and distinguishes metadata notices from unreadable records', async () => {
   const root = await mkdtemp(path.join(os.tmpdir(), 'ct-swift-state-'))
   let source = (await readFile(path.join(here, 'menubar.swift'), 'utf8')).split('@main\nstruct TransplantApp: App {')[0]

--- a/transplant.test.js
+++ b/transplant.test.js
@@ -3698,3 +3698,93 @@ test('process registry identifies a new worker without argv ids and rejects stal
   const foreign = parseProcesses(processes, commands, '/Applications/Claude.app', [{ ...registration, pidDomain: 'linux' }])
   assert.deepEqual(foreign.find(row => row.pid === 502).ids, [])
 })
+
+test('v4 receipt hashes remain compatible when branch and PR metadata are present', async () => {
+  const h = await home()
+  await h.write(SOURCE, [entry('user', 3, null, SOURCE)])
+  await h.record('P', SOURCE, { writtenBranches: ['main'], prs: [{ prNumber: 1 }] })
+  const all = await accounts(h.paths), from = all.find(row => row.account === h.acct.P), to = all.find(row => row.account === h.acct.T)
+  const moved = await move(await inventory([from], to, h.paths, () => {}, { processes: [] }), to, h.paths)
+  const row = moved.receipt.sessions[0]
+  row.recordSemantic = '7b5b2992732164b31c3ae3b416a018059913aac538db4428eedc3d730c8db11b'
+  row.recordKeepSemantic = 'c00b0c7d49c395eb2fd0cc14836e946c3d9fcf141619fecdaecf6803eaa851ad'
+  await writeFile(moved.file, JSON.stringify(moved.receipt))
+  assert.ok((await undo(h.paths)).dest)
+  assert.deepEqual(await readdir(h.dir('T')), [])
+  assert.deepEqual(JSON.parse(await readFile(path.join(h.dir('P'), `local_${SOURCE}.json`))).writtenBranches, ['main'])
+})
+
+test('Swift queues the clicked command once and distinguishes metadata notices from unreadable records', async () => {
+  const root = await mkdtemp(path.join(os.tmpdir(), 'ct-swift-state-'))
+  let source = (await readFile(path.join(here, 'menubar.swift'), 'utf8')).split('@main\nstruct TransplantApp: App {')[0]
+  const start = source.indexOf('    private func run(_ args: [String]')
+  const end = source.indexOf('\nstruct RowKey: PreferenceKey', start)
+  assert.ok(start > 0 && end > start)
+  source = source.slice(0, start) + `    private func run(_ args: [String], line: @escaping (String) -> Void, done: @escaping (Int32, String) -> Void) {
+        requests.append((args, line, done))
+    }
+}
+` + source.slice(end)
+  source = source.replace('guard !running, !sweeping, !snapshot else { return }', 'guard !running, !sweeping else { return }')
+  source += String.raw`
+@MainActor var requests: [([String], (String) -> Void, (Int32, String) -> Void)] = []
+extension Model {
+    func checkSweep() { sweep() }
+}
+@main
+struct StateChecks {
+    @MainActor
+    static func main() {
+        let model = Model(demo: Demo.accounts)
+        model.selectTarget(Demo.accounts[2].id)
+        let selected = model.to
+        model.checkSweep()
+        precondition(model.ready && !model.running)
+        model.move()
+        precondition(model.running && !model.ready && model.displaySummary == "Waiting for background check")
+        model.selectTarget(Demo.accounts[3].id)
+        precondition(model.to == selected)
+        model.to = Demo.accounts[3].id
+        model.undo()
+        precondition(requests.count == 1)
+        requests[0].1("{\"swept\":true,\"ok\":true}")
+        requests[0].2(0, "")
+        precondition(requests.count == 2)
+        let command = requests[1].0
+        precondition(command[command.firstIndex(of: "--to")! + 1] == Demo.accounts[2].selector)
+        precondition(!command.contains("undo"))
+        precondition(!model.sweeping && model.running)
+        for field in ["record unavailable", "isStarred", "title", "isArchived"] {
+            requests = []
+            let item = Model(demo: Demo.accounts)
+            item.checkSweep()
+            requests[0].1("{\"swept\":true,\"ok\":true,\"changed\":[{\"id\":\"fixture\",\"title\":\"Fixture\",\"fields\":[\"" + field + "\"]}]}")
+            requests[0].2(0, "")
+            let unavailable = field == "record unavailable"
+            precondition(item.symbol == (unavailable ? "exclamationmark.triangle" : "info.circle"))
+            precondition(item.note.contains(unavailable ? "cannot be read" : ["isStarred": "starred state", "isArchived": "archive state", "title": "title"][field]!))
+            precondition(item.detailLines.contains { $0.1.contains("Fixture") })
+        }
+        print("Swift queue and metadata states passed")
+    }
+}
+`
+  const file = path.join(root, 'checks.swift'), binary = path.join(root, 'checks')
+  await writeFile(file, source)
+  await promisify(execFile)('/usr/bin/swiftc', ['-parse-as-library', '-o', binary, file], { timeout: 90_000 })
+  const { stdout } = await promisify(execFile)(binary, [], { timeout: 15_000 })
+  assert.match(stdout, /Swift queue and metadata states passed/)
+})
+
+test('missing and unreadable moved records remain distinct from informational field changes', async () => {
+  const h = await home()
+  await h.write(SOURCE, [entry('user', 1, null, SOURCE)])
+  await h.record('P', SOURCE)
+  const all = await accounts(h.paths), from = all.find(row => row.account === h.acct.P), to = all.find(row => row.account === h.acct.T)
+  const moved = await move(await inventory([from], to, h.paths), to, h.paths)
+  const file = moved.receipt.sessions[0].record
+  await unlink(file)
+  assert.deepEqual((await verifyPlaced(h.paths)).changed[0].fields, ['record unavailable'])
+  await writeFile(file, '{')
+  assert.deepEqual((await verifyPlaced(h.paths)).changed[0].fields, ['record unavailable'])
+})


### PR DESCRIPTION
v4.0.1 fixes the panel changing emphasis on open and removes false metadata notices from normal Desktop bookkeeping. The live panel uses an opaque dark background, a dark color scheme, and the active control palette. Background sweeps do not dim the controls.

A click during a sweep captures the exact command and account selection. The panel shows a waiting state, prevents replacement actions, and dispatches that command once the sweep finishes. Missing or unreadable records retain a warning and appear in Details. Informational notices name changes to title, archive state, and starred state.

Branch and PR bookkeeping are runtime metadata for Undo, retirement, and source archival. Updating writtenBranches or prs no longer blocks those operations. There is no compatibility layer for older receipt hashes, following the owner's explicit decision to prioritize the new-user behavior. The queue and warning fixes remain unchanged.

The owner's revised README and aligned terminal example are preserved. Package version is 4.0.1.

Validation: 158 tests in CI, including compiled Swift Model tests for immutable queued selection and warning classification. Additional isolated checks confirmed Undo accepts appended branch/PR metadata but still rejects changed titles and archive state. The earlier actual-popup check captured five identical frames while its background sweep ran, and the owner's completed move and Claude processes were unchanged.

No independent PR-review rounds were run. Merge and publication to GitHub and npm are authorized by the owner after checking the final push.
