### PR TITLE
readme: document what each command touches

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,20 @@ To    ↑↓ move · enter confirm
 | `--json` | one event per line |
 | `--version` | print the version |
 
+## What each command touches
+
+| Command | Writes |
+|---|---|
+| `accounts`, `--dry-run`, `--version` | nothing on disk, `--dry-run --cloud` also reads Remote Control metadata over the network |
+| `restart` without a token | the plan file under the tool's own folder |
+| move, `finish`, `sweep`, `undo` | Desktop session records under `claude-code-sessions`, the receipt, quarantine, and drift evidence |
+| `keep-local` | the receipt only |
+| `--restart-approved <token>` | quits and reopens Claude Desktop, then the same as a move |
+| `--cloud` | archives the source's Remote Control mirrors on `claude.ai` and may write one rescued local transcript, using Desktop's session read from Keychain in memory, network to `claude.ai` only |
+| `menubar`, `menubar --remove` | the app under `~/Library/Application Support/claude-transplant` and a LaunchAgent under `~/Library/LaunchAgents` |
+
+Command and flag names are stable. Renames get a deprecation release first.
+
 ## Reading the output
 
 - without history: transcript no longer exists on disk

--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ Every command may write the tool's own files under `~/Library/Application Suppor
 | `--restart-approved <token>` | quits and reopens Claude Desktop, then the same as a move |
 | a move with `--cloud`, and `finish`, `sweep`, `undo`, or `restart` while the receipt has pending or staged cloud work | Desktop's claude.ai session read from Keychain in memory, network to `claude.ai` only, Remote Control mirrors archived or restored there, rescued local transcripts when a remote branch diverged |
 | `menubar`, `menubar --remove` | the app bundle in the tool's folder and a LaunchAgent under `~/Library/LaunchAgents` |
+| Move in the menubar | the same as a move with `--cloud`, the panel always passes it |
 | `menubar --snapshot <png>` | that image file |
 
 Command and flag names are stable. Renames get a deprecation release first.

--- a/README.md
+++ b/README.md
@@ -75,15 +75,17 @@ To    ↑↓ move · enter confirm
 
 ## What each command touches
 
-| Command | Writes |
+Every command may write the tool's own files under `~/Library/Application Support/claude-transplant`: cache, lock, restart plan, receipts, quarantine, and drift evidence. A move, `finish`, `sweep`, `undo`, and `restart` first finish any interrupted move, retirement, undo, or restart, which can move records, rewrite the receipt and quarantine, and reopen Claude Desktop. `--dry-run` and `keep-local` refuse in that state instead.
+
+| Command | Beyond the tool's own folder |
 |---|---|
-| `accounts`, `--dry-run`, `--version` | nothing on disk, `--dry-run --cloud` also reads Remote Control metadata over the network |
-| `restart` without a token | the plan file under the tool's own folder |
-| move, `finish`, `sweep`, `undo` | Desktop session records under `claude-code-sessions`, the receipt, quarantine, and drift evidence |
-| `keep-local` | the receipt only |
+| `accounts`, `--dry-run`, `--version`, `keep-local` | nothing, `--dry-run --cloud` also reads Remote Control metadata over the network |
+| `restart` without a token | nothing beyond the recovery above |
+| move, `finish`, `sweep`, `undo` | Desktop session records under `claude-code-sessions` |
 | `--restart-approved <token>` | quits and reopens Claude Desktop, then the same as a move |
-| `--cloud` | archives the source's Remote Control mirrors on `claude.ai` and may write one rescued local transcript, using Desktop's session read from Keychain in memory, network to `claude.ai` only |
-| `menubar`, `menubar --remove` | the app under `~/Library/Application Support/claude-transplant` and a LaunchAgent under `~/Library/LaunchAgents` |
+| a move with `--cloud`, and `finish`, `sweep`, `undo`, or `restart` while the receipt has pending or staged cloud work | Desktop's claude.ai session read from Keychain in memory, network to `claude.ai` only, Remote Control mirrors archived or restored there, rescued local transcripts when a remote branch diverged |
+| `menubar`, `menubar --remove` | the app bundle in the tool's folder and a LaunchAgent under `~/Library/LaunchAgents` |
+| `menubar --snapshot <png>` | that image file |
 
 Command and flag names are stable. Renames get a deprecation release first.
 


### PR DESCRIPTION
Adds a table after the CLI command list saying which commands only read and which write session records, the receipt, Claude Desktop, or claude.ai, plus a line that command and flag names are stable. Generic, no product named. Requested by a guard-tool maintainer in the r/ClaudeCode thread so pre-execution reviewers can allow reads and pause writes.

Checked against 4.0.2: dry-run opens the analysis cache read-only, a token-less restart saves only its plan file, menubar installs the app bundle and a LaunchAgent, and --cloud archives mirrors and may write one rescued transcript.

🤖 Generated with [Claude Code](https://claude.com/claude-code)