### PR TITLE
Fix session replays and Finish reporting

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ To    ↑↓ move · enter confirm
 | `claude-transplant` | pick From and To, move, print a receipt |
 | `--dry-run` | plan only, write nothing |
 | `undo` | quarantine the last move and restore source entries, refused if a target changed or a source cannot be restored |
-| `finish` | finish held local records, check the active pending cloud source, or continue a staged cloud undo |
+| `finish` | finish held local records or active-source cloud checks, continue a staged cloud undo, and list sessions the last move refused |
 | `sweep` | verify placed records and retry eligible pending work, never requests a restart |
 | `restart` | show the plan for the existing Desktop refresh action |
 | `keep-local` | cancel held work and pending cloud checks without reversing completed moves |
@@ -129,7 +129,7 @@ Safety:
 - Interrupted retirement or undo resumes from the receipt. A corrupt newest receipt stops undo.
 - Later moves and sweeps report changes to title, archive state, and starred state under `drift/<receipt>`. Other Desktop bookkeeping stays quiet. Missing or unreadable records retain a warning. Undo, retirement, and source archival also ignore branch and PR bookkeeping.
 - Background checks keep the panel enabled. A click captures its command and selection, shows a waiting state, and cannot be replaced by another action before the check finishes.
-- Lineage follows `forkedFrom` pointers to their roots. Duplicate message ids that differ only in runtime metadata count as sync replays, anything else is refused.
+- Lineage follows `forkedFrom` pointers to their roots. Duplicate message ids count as sync replays when only runtime metadata differs, or an otherwise identical copy leaves command output or file-read content empty. Conflicting contents are refused.
 - A disposable planning cache lives at `~/Library/Application Support/claude-transplant/cache.json`. Every write decision uses live files. Delete it any time.
 
 ## Rules

--- a/menubar.swift
+++ b/menubar.swift
@@ -606,10 +606,12 @@ final class Model: ObservableObject {
             if clean, !restartAvailable, failedFinish == nil || result?.receipt == failedFinish, let sweepNote, note == sweepNote {
                 note = ""
                 symbol = "arrow.left.arrow.right"
+                self.sweepNote = nil
             }
-            if result != nil { sweepNote = nil; lines.removeAll { $0.0 == "metadata" } }
+            if result != nil { lines.removeAll { $0.0 == "metadata" } }
             let previousNote = note
             if let problem {
+                lines.removeAll { $0.0 == "background" }
                 lines.append(("background", problem))
                 note = "The remaining work needs attention"
                 symbol = "exclamationmark.triangle"

--- a/menubar.swift
+++ b/menubar.swift
@@ -242,6 +242,7 @@ final class Model: ObservableObject {
     private var operationArgs: [String] = []
     private var operationStarted: TimeInterval?
     private var operationDestination: String?
+    private var failedFinish = false
     private var approvalAttempted = false
     private var poller: AnyCancellable?
     private var progressTimer: AnyCancellable?
@@ -367,6 +368,7 @@ final class Model: ObservableObject {
     }
 
     private func clearResult() {
+        failedFinish = false
         selectionComplete = false
         lines = []
         detailsExpanded = false
@@ -379,10 +381,17 @@ final class Model: ObservableObject {
         guard !refreshing, !running, !sweeping else { return }
         refreshing = true
         var text = ""
-        run(["accounts", "--json"], line: { text += $0 }) { [weak self] _, _ in
+        run(["accounts", "--json"], line: { text += $0 }) { [weak self] status, _ in
             guard let self else { return }
             refreshing = false
-            guard let data = text.data(using: .utf8), let list = try? JSONDecoder().decode([Account].self, from: data) else { return }
+            guard status == 0, let data = text.data(using: .utf8), let list = try? JSONDecoder().decode([Account].self, from: data) else { return }
+            if failedFinish, !pendingAccounts.isEmpty, !list.contains(where: { $0.pending != nil }), pendingAccounts.allSatisfy({ source in list.contains { $0.id == source.id } }) {
+                clearResult()
+                pendingResult = false
+                selectionComplete = true
+                note = "No remaining work"
+                symbol = "arrow.left.arrow.right"
+            }
             accounts = list
             settle()
             let identity = list.filter { $0.active == true }.map(\.id).joined(separator: ",")
@@ -414,6 +423,7 @@ final class Model: ObservableObject {
     }
 
     func begin(resetProgress: Bool = true) {
+        failedFinish = false
         lines = []
         detailsExpanded = false
         note = ""
@@ -647,6 +657,7 @@ final class Model: ObservableObject {
             confirmRestart(plan)
             return
         }
+        failedFinish = status != 0 && operationArgs.first == "finish"
         if status != 0 { completion = nil }
         if status == 0, let result = completion, let started = operationStarted {
             completion = (result.summary, "History verified · " + String(format: "%.1f seconds", max(0.1, ProcessInfo.processInfo.systemUptime - started)))

--- a/menubar.swift
+++ b/menubar.swift
@@ -19,6 +19,7 @@ struct Account: Decodable, Identifiable {
     var pendingWaiting: [HeldRecord]? = nil
     var receiptMoved: Int? = nil
     var receiptDestination: String? = nil
+    var receipt: String? = nil
     var id: String { account + "/" + org }
     var selector: String { account + " " + org }
     var name: String { email ?? String(account.prefix(8)) }
@@ -68,6 +69,7 @@ struct MetadataChange: Decodable {
 
 
 struct Event: Decodable {
+    let receipt: String?
     let swept: Bool?
     let error: String?
     let changed: [MetadataChange]?
@@ -112,6 +114,7 @@ struct Event: Decodable {
     let refused: [String]?
     let reason: String?
     let nothing: Bool?
+    var issues: Int { (failed?.count ?? 0) + (problems?.count ?? 0) }
 }
 
 extension String {
@@ -242,7 +245,7 @@ final class Model: ObservableObject {
     private var operationArgs: [String] = []
     private var operationStarted: TimeInterval?
     private var operationDestination: String?
-    private var failedFinish = false
+    private var failedFinish: String?
     private var approvalAttempted = false
     private var poller: AnyCancellable?
     private var progressTimer: AnyCancellable?
@@ -368,7 +371,7 @@ final class Model: ObservableObject {
     }
 
     private func clearResult() {
-        failedFinish = false
+        failedFinish = nil
         selectionComplete = false
         lines = []
         detailsExpanded = false
@@ -385,13 +388,6 @@ final class Model: ObservableObject {
             guard let self else { return }
             refreshing = false
             guard status == 0, let data = text.data(using: .utf8), let list = try? JSONDecoder().decode([Account].self, from: data) else { return }
-            if failedFinish, !pendingAccounts.isEmpty, !list.contains(where: { $0.pending != nil }), pendingAccounts.allSatisfy({ source in list.contains { $0.id == source.id } }) {
-                clearResult()
-                pendingResult = false
-                selectionComplete = true
-                note = "No remaining work"
-                symbol = "arrow.left.arrow.right"
-            }
             accounts = list
             settle()
             let identity = list.filter { $0.active == true }.map(\.id).joined(separator: ",")
@@ -423,7 +419,7 @@ final class Model: ObservableObject {
     }
 
     func begin(resetProgress: Bool = true) {
-        failedFinish = false
+        failedFinish = nil
         lines = []
         detailsExpanded = false
         note = ""
@@ -461,19 +457,17 @@ final class Model: ObservableObject {
             note = event.retry == true ? "Run Undo last again if still wanted" : ""
             restartAvailable = false
         } else if event.done == true {
-            let failed = event.failed ?? [], problems = event.problems ?? []
             let waiting = event.waiting ?? event.held ?? []
             let pendingCloud = event.pendingCloud ?? 0
             pendingResult = event.complete == false || pendingCloud > 0 || !(event.pendingUndo ?? []).isEmpty || !waiting.isEmpty
-            if !failed.isEmpty { lines.append(("issue", failed.map { identity($0.title, $0.id) + " | " + $0.error }.joined(separator: "\n"))) }
-            for problem in problems { lines.append(("check", identity(problem.title, problem.id) + " | " + problem.check + " failed")) }
+            recordIssues(event)
             if !waiting.isEmpty { lines.append(("open", waiting.map(\.title).joined(separator: "\n"))) }
             if let reason = event.reason ?? (event.ok == false ? event.note : nil) { lines.append(("reason", reason)) }
             let moved = event.moved ?? 0
             var parts: [String] = []
             if moved > 0 { parts.append(quantity(moved, "session moved", "sessions moved")) }
             if !waiting.isEmpty { parts.append("\(waiting.count) still open") }
-            let issues = failed.count + problems.count
+            let issues = event.issues
             if issues > 0 { parts.append("\(issues) need attention") }
             else if event.ok == false { parts.append("remaining work needs attention") }
             if pendingCloud > 0 && waiting.isEmpty && issues == 0 { parts.append("remaining sessions will finish when their account is available") }
@@ -501,9 +495,18 @@ final class Model: ObservableObject {
             restartAvailable = false
             lines = refused.map { ("kept", $0) }
         } else if event.nothing == true {
-            note = operationArgs.first == "undo" ? "Nothing to undo" : "No remaining work"
+            recordIssues(event)
+            let refused = event.failed?.count ?? 0, unverified = event.problems?.count ?? 0
+            note = [refused > 0 ? quantity(refused, "session was not moved", "sessions were not moved") : nil,
+                    unverified > 0 ? quantity(unverified, "verification problem", "verification problems") : nil].compactMap { $0 }.joined(separator: ", ")
+            if note.isEmpty { note = operationArgs.first == "undo" ? "Nothing to undo" : "No remaining work" }
             restartAvailable = false
         }
+    }
+
+    private func recordIssues(_ event: Event) {
+        if let failed = event.failed, !failed.isEmpty { lines.append(("issue", failed.map { identity($0.title, $0.id) + " | " + $0.error }.joined(separator: "\n"))) }
+        for problem in event.problems ?? [] { lines.append(("check", identity(problem.title, problem.id) + " | " + problem.check + " verification failed")) }
     }
 
     private func identity(_ title: String?, _ id: String?) -> String {
@@ -598,18 +601,16 @@ final class Model: ObservableObject {
                 }
             }
             if result == nil, error.contains("another run holds the lock") { return }
-            if result != nil, let sweepNote, note == sweepNote {
+            let problem = result?.error.flatMap { $0.isEmpty ? nil : $0 } ?? (status != 0 || result?.ok != true ? (error.isEmpty ? "Background check did not complete" : error) : nil)
+            let clean = problem == nil && result?.issues == 0
+            if clean, !restartAvailable, failedFinish == nil || result?.receipt == failedFinish, let sweepNote, note == sweepNote {
                 note = ""
                 symbol = "arrow.left.arrow.right"
             }
             if result != nil { sweepNote = nil; lines.removeAll { $0.0 == "metadata" } }
             let previousNote = note
-            if result == nil, status != 0 {
-                lines.append(("background", error))
-                note = "The remaining work needs attention"
-                symbol = "exclamationmark.triangle"
-            } else if let error = result?.error, !error.isEmpty {
-                lines.append(("background", error))
+            if let problem {
+                lines.append(("background", problem))
                 note = "The remaining work needs attention"
                 symbol = "exclamationmark.triangle"
             } else if let changed = result?.changed, !changed.isEmpty {
@@ -622,9 +623,18 @@ final class Model: ObservableObject {
                 symbol = unavailable.isEmpty ? "info.circle" : "exclamationmark.triangle"
                 lines.append(("metadata", changed.map { self.identity($0.title, $0.id) + " | " + $0.fields.map { names[$0] ?? $0 }.joined(separator: ", ") }.joined(separator: "\n")))
             }
-            if result?.ok != false, result?.restart == true, result?.changed?.contains(where: { $0.fields.contains("record unavailable") }) != true {
+            if problem == nil, result?.restart == true, result?.changed?.contains(where: { $0.fields.contains("record unavailable") }) != true {
                 restartAvailable = true
                 note = "Pending sessions moved. Restart Claude Desktop to refresh this account."
+            }
+            if clean, let failedFinish, result?.receipt == failedFinish, result?.complete == true,
+               (result?.changed ?? []).isEmpty, pendingAccounts.isEmpty, !restartAvailable {
+                clearResult()
+                pendingResult = false
+                selectionComplete = true
+                note = "No remaining work"
+                symbol = "arrow.left.arrow.right"
+                settle()
             }
             if note != previousNote, !note.isEmpty { sweepNote = note }
         }
@@ -657,7 +667,7 @@ final class Model: ObservableObject {
             confirmRestart(plan)
             return
         }
-        failedFinish = status != 0 && operationArgs.first == "finish" && note.isEmpty
+        failedFinish = status != 0 && operationArgs.first == "finish" && note.isEmpty ? pendingAccounts.first?.receipt : nil
         if status != 0 { completion = nil }
         if status == 0, let result = completion, let started = operationStarted {
             completion = (result.summary, "History verified · " + String(format: "%.1f seconds", max(0.1, ProcessInfo.processInfo.systemUptime - started)))
@@ -672,6 +682,10 @@ final class Model: ObservableObject {
         }
         if !pendingResult && status == 0 { excluded = []; from = []; to = nil; targetChosen = false; selectionComplete = true }
         symbol = pendingResult ? "clock.arrow.circlepath" : status == 0 ? "checkmark" : "exclamationmark.triangle"
+        if status == 0, !pendingResult, !moveProgress.hasProgress, operationArgs.first == "finish" {
+            badge = ""
+            symbol = lines.isEmpty ? "arrow.left.arrow.right" : "info.circle"
+        }
         if status != 0, note.isEmpty { lines.append(("reason", error)); note = "The move needs attention" }
         DispatchQueue.main.asyncAfter(deadline: .now() + 4) { [weak self] in
             guard let self, !self.running else { return }

--- a/menubar.swift
+++ b/menubar.swift
@@ -657,7 +657,7 @@ final class Model: ObservableObject {
             confirmRestart(plan)
             return
         }
-        failedFinish = status != 0 && operationArgs.first == "finish"
+        failedFinish = status != 0 && operationArgs.first == "finish" && note.isEmpty
         if status != 0 { completion = nil }
         if status == 0, let result = completion, let started = operationStarted {
             completion = (result.summary, "History verified · " + String(format: "%.1f seconds", max(0.1, ProcessInfo.processInfo.systemUptime - started)))

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-transplant",
-  "version": "4.0.2",
+  "version": "4.0.3",
   "description": "Move Claude Code history between accounts. Either via menubar or CLI. macOS only.",
   "type": "module",
   "bin": {

--- a/transplant.js
+++ b/transplant.js
@@ -69,6 +69,7 @@ const waitingSessions = (receipt) => [...new Map([
 ].map(row => [row.localId ?? remoteId(row.id) ?? row.id, row])).values()]
 const legacyLocalFailures = (receipt) => receipt.localCancelledAt ? [] : (receipt.failed ?? []).filter(row => row.error === WORKER_OWNS && UUID.test(row.id ?? ''))
 const receiptOkay = (receipt) => receipt.verification?.ok !== false && !receipt.failed?.length
+const problemText = (problem) => `${problem.title ?? problem.id} | ${problem.check} verification failed`
 const cancelCloudChecks = (receipt) => {
   for (const check of openCloudChecks(receipt)) {
     check.status = 'cancelled'
@@ -709,7 +710,6 @@ export async function cloudClient(paths, expected = null, io = {}) {
   const preferredOrg = selected?.org ?? cookies.get('lastActiveOrg')
   const organization = Array.isArray(organizations) ? organizations.find((item) => item.uuid === preferredOrg) : null
   if (!organization) throw new Error('Claude Desktop organization could not be verified')
-  if (expected && (account.uuid !== expected.account || organization.uuid !== expected.org)) throw new Error(`sign Claude Desktop into ${expected.label}`)
   const org = organization.uuid
   const request = (endpoint, options) => raw(endpoint, options, org)
   const session = async (id) => {
@@ -2838,7 +2838,7 @@ export function finishPending(paths, options = {}) {
     if (options.receiptFile && file !== options.receiptFile) return { nothing: true, ok: true }
     const outstanding = openCloudChecks(receipt)
     if (!outstanding.length) {
-      const ok = receiptOkay(receipt)
+      const ok = receipt.verification?.ok !== false && !receipt.verification?.problems?.length
       return { nothing: ok, receipt, file, ok, complete: true, pendingCloud: 0, failed: receipt.failed ?? [], problems: receipt.verification?.problems ?? [] }
     }
     if (options.automatic) {
@@ -2981,7 +2981,7 @@ export function keepLocal(paths) {
       return { file, receipt, cancelled: 0, heldCancelled, labels: [], ok: receiptOkay(receipt), complete: true }
     }
     const unsafe = (receipt.verification?.problems ?? []).filter((problem) => checks.some((check) => cloudTagged(problem, check)))
-    const refused = unsafe.map((problem) => `${problem.title ?? problem.id} | ${problem.check} verification failed`)
+    const refused = unsafe.map(problemText)
     const liveWorkers = workers()
     for (const row of receipt.sessions) {
       const changes = await targetChanges(row, liveWorkers, row.strategy !== 'rehome', true)
@@ -3201,7 +3201,7 @@ async function inspectPlaced(paths) {
     receipt.metadataDrift = changed
     await saveJson(file, receipt)
   }
-  return { changed, receipt: file }
+  return { changed, receipt: file, ok: receiptOkay(receipt), failed: receipt.failed ?? [], problems: receipt.verification?.problems ?? [] }
 }
 
 export const verifyPlaced = (paths) => locked(paths, () => inspectPlaced(paths))
@@ -3216,7 +3216,7 @@ export async function sweep(paths, options = {}) {
     const error = result.reason ?? result.problems?.map((row) => `${row.title}: ${row.check}`).join(', ') ?? result.receipt?.failed.map((row) => `${row.title}: ${row.error}`).join(', ')
     return { verification, result, error: result.ok === false ? error || 'Pending local work needs attention' : null, refreshRequired: !result.receipt?.held.length && result.added > 0 && sameAccount(await signedIn(paths), result.receipt?.toAccount), ok: result.ok !== false }
   }
-  if (!deferred || deferred.mode !== 'cloud') return { verification, ok: !verification.error }
+  if (!deferred || deferred.mode !== 'cloud') return { verification, ok: !verification.error, complete: !deferred && verification.ok === true }
   const active = options.active ?? await signedIn(paths, options.processes)
   const source = deferred.sources.find((row) => sameAccount(row, active))
   if (!source) return { verification, pending: true, ok: true }
@@ -3542,9 +3542,13 @@ async function main(argv) {
   if (args.cmd === 'menubar') return out.write(`${await locked(paths, () => menubar(paths, args.remove, args.snapshot))}\n`)
   if (args.cmd === 'sweep') {
     const result = await sweep(paths)
-    if (args.json) return emit({ swept: true, ok: result.ok, error: result.error, changed: result.verification?.changed ?? [], recovered: result.recovered,
-      pendingLocal: result.result?.pendingLocal, restart: result.refreshRequired, cloudChecked: result.result?.cloudChecked ?? 0, cloudArchived: result.result?.cloudArchived ?? 0, complete: result.result?.complete })
-    return out.write(result.error ? `${result.error}\n` : `${quantity(result.verification?.changed.length ?? 0, 'metadata change')} detected\n`)
+    const failed = result.result?.receipt?.failed ?? result.verification?.failed ?? []
+    const problems = result.result?.receipt?.verification?.problems ?? result.verification?.problems ?? []
+    const error = result.error ?? result.verification?.error ?? (problems.length ? problems.map(problemText).join(', ') : null)
+    if (args.json) return emit({ swept: true, ok: result.ok && !error, error, changed: result.verification?.changed ?? [], recovered: result.recovered,
+      receipt: result.result?.file ?? result.verification?.receipt, failed, problems,
+      pendingLocal: result.result?.pendingLocal, restart: result.refreshRequired, cloudChecked: result.result?.cloudChecked ?? 0, cloudArchived: result.result?.cloudArchived ?? 0, complete: result.result?.complete ?? result.complete })
+    return out.write(error ? `${error}\n` : `${quantity(result.verification?.changed.length ?? 0, 'metadata change')} detected\n`)
   }
   if (args.cmd === 'restart') {
     const result = await executeMove(null, null, paths, { approve: args.restartApproved, approvalStartedAt: began, report: reporter(args.json) })
@@ -3572,9 +3576,9 @@ async function main(argv) {
     const deferred = await deferredWorkflow(paths)
     const result = await finishWorkflow(paths, { approve: args.restartApproved, approvalStartedAt: began, moveOnly: args.moveOnly, report })
     if (result.plan) return showPlan(result.plan)
-    if (result.ok === false || result.recoveryRequired || result.restoreProblems?.length || result.failed?.length || result.pendingUndo?.length) process.exitCode = 1
+    if (result.ok === false || result.recoveryRequired || result.restoreProblems?.length || (!result.nothing && result.failed?.length) || result.problems?.length || result.pendingUndo?.length) process.exitCode = 1
     if (args.json) {
-      if (result.nothing) return emit({ nothing: true })
+      if (result.nothing) return emit({ nothing: true, failed: result.failed ?? [], problems: result.problems ?? [] })
       if (result.reconciled) return emit({ done: true, ok: false, recoveryRequired: true, reconciled: result.reconciled })
       if (result.recoveryRequired) return emit({ done: true, ok: false, recoveryRequired: true, reason: 'Recovery remains pending' })
       if (result.dest) return emit({ undone: result.receipt.at, sessions: result.receipt.sessions.length, restored: retiredCount(result.receipt), cloudRestored: result.receipt.remote?.length ?? 0, restart: Boolean(result.receipt.sessions.length || result.receipt.superseded?.length || result.receipt.remote?.length) })
@@ -3601,12 +3605,14 @@ async function main(argv) {
         restart: result.restart ?? false
       })
     }
-    if (result.nothing) return out.write('nothing pending\n')
+    if (result.nothing) out.write('nothing pending\n')
     if (result.reconciled) return out.write(`recovered   ${result.reconciled.title} | ${result.reconciled.error}\n  finish      not run, review the recovery and try again\n`)
     if (result.recoveryRequired) return out.write('  pending     recovery remains incomplete\n')
     if (result.dest) return out.write(`Undo  ${result.receipt.at} completed\n`)
     if (result.pendingUndo?.length) return out.write(`  pending     sign Claude Desktop into ${result.pendingUndo.join(' or ')} and run finish again\n`)
-    if (result.failed?.length) out.write(`  failed      ${result.failed.map((failure) => `${failure.title || failure.id} | ${failure.error}`).join('\n              ')}\n`)
+    if (result.failed?.length) out.write(`  ${result.nothing ? 'not moved' : 'failed   '}   ${result.failed.map((failure) => `${failure.title || failure.id} | ${failure.error}`).join('\n              ')}\n`)
+    if (result.problems?.length) out.write(`  failed      ${result.problems.map(problemText).join('\n              ')}\n`)
+    if (result.nothing) return
     const pending = result.pendingLabels?.length ? ` | ${result.pendingLabels.join(', ')}` : ''
     return out.write(result.complete ? '  cloud       all source checks complete\n' : `  pending     ${result.pendingCloud} cloud checks${pending}\n`)
   }
@@ -3690,7 +3696,8 @@ async function main(argv) {
           pendingWaiting: waiting,
           receiptMoved: source ? deferred.receipt.sessions.length : null,
           receiptDestination: source ? `${deferred.receipt.toAccount.account}/${deferred.receipt.toAccount.org}` : null,
-          pendingFailures: source?.failures ?? []
+          pendingFailures: source?.failures ?? [],
+          receipt: source ? deferred.file : null
         }
       }))
     }

--- a/transplant.js
+++ b/transplant.js
@@ -670,10 +670,13 @@ const remoteId = (id) => {
   try { return wireRemoteId(id) } catch { return null }
 }
 
-export async function cloudClient(paths, expected = null) {
-  const cookies = desktopCookies(paths)
+export async function cloudClient(paths, expected = null, io = {}) {
+  const current = io.active ?? await signedIn(paths)
+  if (current.state === 'logged-out') throw new Error('Claude Desktop is signed out')
+  const selected = expected ?? (current.state === 'known' ? current : null)
+  const cookies = io.cookies ?? desktopCookies(paths)
   const cookie = [...cookies].map(([name, value]) => `${name}=${value}`).join('; ')
-  const userAgent = await desktopUserAgent(paths)
+  const userAgent = io.userAgent ?? await desktopUserAgent(paths)
   const baseHeaders = {
     accept: 'application/json',
     cookie,
@@ -701,8 +704,9 @@ export async function cloudClient(paths, expected = null) {
   }
   const account = await raw('/api/account')
   if (!UUID.test(account?.uuid ?? '')) throw new Error('Claude Desktop account could not be verified')
+  if (selected?.account && account.uuid !== selected.account) throw new Error(expected ? `sign Claude Desktop into ${expected.label}` : 'Claude Desktop login is still updating. Try again in a moment.')
   const organizations = await raw('/api/organizations')
-  const preferredOrg = expected?.org ?? cookies.get('lastActiveOrg') ?? (await signedIn(paths)).org
+  const preferredOrg = selected?.org ?? cookies.get('lastActiveOrg')
   const organization = Array.isArray(organizations) ? organizations.find((item) => item.uuid === preferredOrg) : null
   if (!organization) throw new Error('Claude Desktop organization could not be verified')
   if (expected && (account.uuid !== expected.account || organization.uuid !== expected.org)) throw new Error(`sign Claude Desktop into ${expected.label}`)

--- a/transplant.js
+++ b/transplant.js
@@ -22,7 +22,7 @@ const RESTART_BUDGET = 30_000
 const REOPEN_RESERVE = 8_000
 const LABEL = 'io.github.vitaliyhayda.claude-transplant'
 const SEMANTIC_VERSION = 3
-const CACHE_VERSION = 7
+const CACHE_VERSION = 8
 const RUNTIME_KEYS = ['slug', 'promptId', 'parentUuid', 'version', 'cwd', 'gitBranch']
 const MESSAGE_RUNTIME_KEYS = ['id', 'usage', 'diagnostics', 'stop_reason', 'stop_sequence', 'stop_details']
 const RECORD_RUNTIME_KEYS = ['lastActivityAt', 'lastFocusedAt', 'completedTurns', 'error', 'errorAt', 'priorErrorMark', 'lastSpawnRootDetected', 'promptAppendSnapshot', 'reportFindingsCard', 'scratchPromptRecents', 'writtenBranches', 'prs']
@@ -867,28 +867,33 @@ const keepRecordSemantic = (record) => sha(stable(without(record, [...RECORD_RUN
 
 const semanticShape = (entry) => stable(without(entry, RUNTIME_KEYS))
 
-const replayShape = (entry) => {
-  const c = without(entry, RUNTIME_KEYS)
-  if (c.toolUseResult && typeof c.toolUseResult === 'object' && !Array.isArray(c.toolUseResult)) {
-    delete c.toolUseResult.stdout
-    delete c.toolUseResult.stderr
+const OUTPUT_KEYS = ['stdout', 'stderr', 'fileContent']
+const toolOutput = (entry) => ({ stdout: entry.toolUseResult?.stdout, stderr: entry.toolUseResult?.stderr, fileContent: entry.toolUseResult?.file?.content })
+
+const stripToolOutput = (entry) => {
+  const result = entry.toolUseResult
+  if (result && typeof result === 'object' && !Array.isArray(result)) {
+    delete result.stdout
+    delete result.stderr
+    if (typeof result.file?.content === 'string') delete result.file.content
   }
-  return stable(c)
+  return entry
 }
 
-const richness = (e) => ['stdout', 'stderr'].reduce((n, k) => n + (typeof e.toolUseResult?.[k] === 'string' ? Buffer.byteLength(e.toolUseResult[k]) : 0), 0)
+const replayShape = (entry) => stable(stripToolOutput(without(entry, RUNTIME_KEYS)))
+const richness = (entry) => Object.values(toolOutput(entry)).reduce((n, value) => n + (typeof value === 'string' ? Buffer.byteLength(value) : 0), 0)
 
 function survivor(rows, ids) {
   if (new Set(rows.map((r) => replayShape(r.entry))).size !== 1) return null
   if (rows.some((r) => r.entry.parentUuid && !ids.has(r.entry.parentUuid))) return null
   const keep = {}
-  for (const k of ['stdout', 'stderr']) {
-    const values = new Set(rows.map((r) => r.entry.toolUseResult?.[k]).filter((v) => typeof v === 'string' && v.length))
+  for (const k of OUTPUT_KEYS) {
+    const values = new Set(rows.map((r) => toolOutput(r.entry)[k]).filter((v) => typeof v === 'string' && v.length))
     if (values.size > 1) return null
     keep[k] = [...values][0] ?? ''
   }
   const ranked = rows.toSorted((a, b) => richness(b.entry) - richness(a.entry) || a.line - b.line)
-  return ranked.find((r) => ['stdout', 'stderr'].every((k) => !keep[k] || r.entry.toolUseResult?.[k] === keep[k]))?.line ?? null
+  return ranked.find((r) => OUTPUT_KEYS.every((k) => !keep[k] || toolOutput(r.entry)[k] === keep[k]))?.line ?? null
 }
 
 export function normalize(entries) {
@@ -969,23 +974,20 @@ async function origins(id, ctx, cwd = '') {
 
 const lineageEvent = (entry) => {
   const c = without(entry, RUNTIME_KEYS)
-  const output = { stdout: null, stderr: null }
+  const output = Object.fromEntries(Object.entries(toolOutput(c)).map(([key, value]) => [key, typeof value === 'string' && value ? sha(value) : null]))
   const ignored = [
     'uuid', 'logicalParentUuid', 'sessionId', 'timestamp',
     'forkedFrom', 'teamName', 'agentName', 'sessionKind', 'sourceToolAssistantUUID', 'neutralizedByFork'
   ]
   for (const k of ignored) delete c[k]
+  stripToolOutput(c)
   if (c.toolUseResult && typeof c.toolUseResult === 'object' && !Array.isArray(c.toolUseResult)) {
-    for (const k of ['stdout', 'stderr']) {
-      if (typeof c.toolUseResult[k] === 'string' && c.toolUseResult[k]) output[k] = sha(c.toolUseResult[k])
-      delete c.toolUseResult[k]
-    }
     if (!Object.keys(c.toolUseResult).length) delete c.toolUseResult
   }
   return { base: sha(stable(c)), ...output }
 }
 
-const eventIncluded = (a, b) => Boolean(b) && a.base === b.base && ['stdout', 'stderr'].every((k) => !a[k] || a[k] === b[k])
+const eventIncluded = (a, b) => Boolean(b) && a.base === b.base && OUTPUT_KEYS.every((k) => !a[k] || a[k] === b[k])
 
 const messageHash = (type, value) => sha(stable({ type, message: without(value, MESSAGE_RUNTIME_KEYS) }))
 
@@ -2835,7 +2837,10 @@ export function finishPending(paths, options = {}) {
     const { file, receipt } = latest
     if (options.receiptFile && file !== options.receiptFile) return { nothing: true, ok: true }
     const outstanding = openCloudChecks(receipt)
-    if (!outstanding.length) return { nothing: true, receipt, file, ok: true, complete: true, pendingCloud: 0 }
+    if (!outstanding.length) {
+      const ok = receiptOkay(receipt)
+      return { nothing: ok, receipt, file, ok, complete: true, pendingCloud: 0, failed: receipt.failed ?? [], problems: receipt.verification?.problems ?? [] }
+    }
     if (options.automatic) {
       const key = `${options.automatic.account}/${options.automatic.org}`
       const previous = receipt.automaticCloudAttempt

--- a/transplant.test.js
+++ b/transplant.test.js
@@ -9,7 +9,7 @@ import path from 'node:path'
 import test from 'node:test'
 import { fileURLToPath } from 'node:url'
 import { promisify } from 'node:util'
-import { accounts, executeMove, finishHeld, finishPending, finishWorkflow, inventory, keepLocal, layout, move, normalize, parseProcesses, restartPlan, resumeLast, semantic, signedIn, step, sweep, undo, verifyPlaced, withDesktopRestart, writeNew } from './transplant.js'
+import { accounts, cloudClient, executeMove, finishHeld, finishPending, finishWorkflow, inventory, keepLocal, layout, move, normalize, parseProcesses, restartPlan, resumeLast, semantic, signedIn, step, sweep, undo, verifyPlaced, withDesktopRestart, writeNew } from './transplant.js'
 
 const here = path.dirname(fileURLToPath(import.meta.url))
 const SOURCE = '00000000-0000-4000-8000-000000000001'
@@ -1569,6 +1569,68 @@ test('signed-in identity follows an offline switch without using network-depende
   await f.write(f.init() + f.event(1, `[LocalSessionManager] Org changed from ${h.org.P} to ${h.org.T}, reinitializing sessions`) + f.init(2, h.acct.P, h.org.T) + f.event(3, 'Failed to check allowlist status: offline'))
   assert.equal((await signedIn(h.paths, f.processes)).org, h.org.T)
   assert.equal(network.mock.callCount(), 0)
+})
+
+test('Finish uses the active Desktop organization when its saved cookie still names the previous organization', async (t) => {
+  const h = await home()
+  await h.write(SOURCE, [entry('user', 1, null, SOURCE)])
+  await h.record('P', SOURCE, rehomeRecord({ title: 'Switched organization' }))
+  await h.record('P', id(997), rehomeRecord({ title: 'Pending source' }))
+  const all = await accounts(h.paths), from = all.find(row => row.account === h.acct.P), to = all.find(row => row.account === h.acct.T)
+  const moved = await move(await inventory([from], to, h.paths, () => {}, { cloudRequested: true }), to, h.paths)
+  assert.equal(moved.pendingCloud, 1)
+  await unlink(path.join(h.dir('P'), `local_${id(997)}.json`))
+  const requestedOrgs = []
+  t.mock.method(globalThis, 'fetch', async (url, options) => {
+    const endpoint = new URL(url).pathname
+    if (endpoint === '/api/account') return Response.json({ uuid: h.acct.P })
+    if (endpoint === '/api/organizations') return Response.json([{ uuid: h.org.P }, { uuid: h.org.T }])
+    assert.equal(endpoint, '/v1/code/sessions')
+    assert.equal(options.method ?? 'GET', 'GET')
+    requestedOrgs.push(options.headers['x-organization-uuid'])
+    return Response.json({ data: [] }, { headers: { 'anthropic-organization-id': options.headers['x-organization-uuid'] } })
+  })
+  const cloud = await cloudClient(h.paths, null, {
+    active: { account: h.acct.P, org: h.org.P, state: 'known' },
+    cookies: new Map([['sessionKey', 'fixture'], ['lastActiveOrg', h.org.T]]),
+    userAgent: 'fixture'
+  })
+  const finished = await finishPending(h.paths, { cloud })
+  assert.equal(finished.ok, true)
+  assert.equal(finished.complete, true)
+  assert.equal(finished.pendingCloud, 0)
+  assert.deepEqual(requestedOrgs, [h.org.P])
+})
+
+test('cloud identity rejects a stale authenticated account even when both logins share the organization', async (t) => {
+  const h = await home(), requested = []
+  t.mock.method(globalThis, 'fetch', async (url) => {
+    requested.push(new URL(url).pathname)
+    if (requested.at(-1) === '/api/account') return Response.json({ uuid: h.acct.T })
+    return Response.json([{ uuid: h.org.P }])
+  })
+  await assert.rejects(cloudClient(h.paths, null, {
+    active: { account: h.acct.P, org: h.org.P, state: 'known' },
+    cookies: new Map([['sessionKey', 'fixture'], ['lastActiveOrg', h.org.P]]),
+    userAgent: 'fixture'
+  }), /login is still updating/)
+  assert.deepEqual(requested, ['/api/account'])
+})
+
+test('cloud identity retains verified cookie fallback for unknown Desktop state and rejects an explicit logout', async (t) => {
+  const h = await home(), requested = []
+  t.mock.method(globalThis, 'fetch', async (url) => {
+    requested.push(new URL(url).pathname)
+    return Response.json(requested.at(-1) === '/api/account' ? { uuid: h.acct.P } : [{ uuid: h.org.P }, { uuid: h.org.T }])
+  })
+  const io = { active: { state: 'unknown', account: null, org: null }, cookies: new Map([['sessionKey', 'fixture'], ['lastActiveOrg', h.org.P]]), userAgent: 'fixture' }
+  assert.equal((await cloudClient(h.paths, null, io)).org, h.org.P)
+  assert.equal((await cloudClient(h.paths, { account: h.acct.P, org: h.org.T, label: 'Team' }, io)).org, h.org.T)
+  requested.length = 0
+  await assert.rejects(cloudClient(h.paths, null, { ...io, active: { state: 'logged-out' } }), /signed out/)
+  assert.deepEqual(requested, [])
+  await assert.rejects(cloudClient(h.paths, { account: h.acct.T, org: h.org.T, label: 'Other login' }, io), /sign Claude Desktop into Other login/)
+  assert.deepEqual(requested, ['/api/account'])
 })
 
 async function home() {
@@ -4041,6 +4103,26 @@ struct StateChecks {
             precondition(item.note.contains(unavailable ? "cannot be read" : ["isStarred": "starred state", "isArchived": "archive state", "title": "title"][field]!))
             precondition(item.detailLines.contains { $0.1.contains("Fixture") })
         }
+        func accountResponse(_ pending: Bool) -> String {
+            String(data: try! JSONSerialization.data(withJSONObject: Demo.accounts.enumerated().map { index, account -> [String: Any] in
+                var row: [String: Any] = ["account": account.account, "org": account.org, "label": account.label, "active": index == 0]
+                if pending && index == 0 { row["pending"] = "cloud"; row["pendingAction"] = "finish" }
+                return row
+            }), encoding: .utf8)!
+        }
+        requests = []
+        let recovering = Model(demo: try! JSONDecoder().decode([Account].self, from: Data(accountResponse(true).utf8)))
+        recovering.finishPending()
+        precondition(requests[0].0 == ["finish", "--json"])
+        requests[0].2(1, "Sign Claude Desktop into Personal")
+        requests[1].1(accountResponse(true))
+        requests[1].2(0, "")
+        precondition(recovering.note == "The move needs attention" && recovering.pendingReady)
+        recovering.refresh()
+        requests[2].1(accountResponse(false))
+        requests[2].2(0, "")
+        precondition(recovering.note == "No remaining work" && !recovering.pendingReady)
+        precondition(recovering.lines.isEmpty && recovering.to == nil && recovering.from.isEmpty)
         print("Swift queue and metadata states passed")
     }
 }

--- a/transplant.test.js
+++ b/transplant.test.js
@@ -1002,7 +1002,7 @@ test('a conflicting same-root history is refused instead of hidden', async () =>
   assert.match(result.receipt.failed[0].error, /conflicting duplicate uuids/)
 })
 
-test('Finish reports recorded local failures even after all queued work is complete', async () => {
+test('idle Finish reports refused sessions quietly while verification errors remain failures', async () => {
   const h = await home()
   const bad = entry('user', 1, null, SOURCE)
   await h.write(SOURCE, [bad, { ...bad, message: { role: 'user', content: 'conflicting body' } }])
@@ -1014,11 +1014,37 @@ test('Finish reports recorded local failures even after all queued work is compl
   assert.equal(moved.receipt.sessions.length, 1)
   assert.equal(moved.receipt.failed.length, 1)
   const result = await cli(h.root, ['finish', '--json'])
-  assert.equal(result.code, 1)
-  const done = lines(result.stdout).find(row => row.done)
-  assert.equal(done.ok, false)
-  assert.match(done.failed[0].error, /conflicting duplicate uuids/)
-  assert.equal(lines(result.stdout).some(row => row.nothing), false)
+  assert.equal(result.code, 0)
+  const idle = lines(result.stdout).find(row => row.nothing)
+  assert.match(idle.failed[0].error, /conflicting duplicate uuids/)
+  const text = await cli(h.root, ['finish'])
+  assert.equal(text.code, 0)
+  assert.match(text.stdout, /nothing pending\n.*not moved.*conflicting duplicate uuids/s)
+  const refused = lines((await cli(h.root, ['sweep', '--json'])).stdout)[0]
+  assert.equal(refused.receipt, moved.file)
+  assert.equal(refused.complete, false)
+  assert.equal(refused.failed.length, 1)
+  const receipt = JSON.parse(await readFile(moved.file, 'utf8'))
+  receipt.failed = []
+  await writeFile(moved.file, JSON.stringify(receipt))
+  const clean = lines((await cli(h.root, ['sweep', '--json'])).stdout)[0]
+  assert.equal(clean.complete, true)
+  assert.equal(clean.receipt, moved.file)
+  receipt.verification = { ok: false, problems: [{ id: id(994), check: 'transcript' }] }
+  await writeFile(moved.file, JSON.stringify(receipt))
+  const unverified = await cli(h.root, ['finish', '--json'])
+  assert.equal(unverified.code, 1)
+  assert.deepEqual(lines(unverified.stdout).find(row => row.done).problems, receipt.verification.problems)
+  const details = await cli(h.root, ['finish'])
+  assert.equal(details.code, 1)
+  assert.ok(details.stdout.includes(`${id(994)} | transcript verification failed`))
+  const checked = lines((await cli(h.root, ['sweep', '--json'])).stdout)[0]
+  assert.equal(checked.ok, false)
+  assert.match(checked.error, /transcript verification failed/)
+  await writeFile(moved.file, '{')
+  const corrupt = lines((await cli(h.root, ['sweep', '--json'])).stdout)[0]
+  assert.equal(corrupt.ok, false)
+  assert.match(corrupt.error, /corrupt receipt/)
 })
 
 test('new sidecars remain visible through a shared transcript', async () => {
@@ -4168,7 +4194,7 @@ struct StateChecks {
         func accountResponse(_ pending: Bool) -> String {
             String(data: try! JSONSerialization.data(withJSONObject: Demo.accounts.enumerated().map { index, account -> [String: Any] in
                 var row: [String: Any] = ["account": account.account, "org": account.org, "label": account.label, "active": index == 0]
-                if pending && index == 0 { row["pending"] = "cloud"; row["pendingAction"] = "finish" }
+                if pending && index == 0 { row["pending"] = "cloud"; row["pendingAction"] = "finish"; row["receipt"] = "receipt-one" }
                 return row
             }), encoding: .utf8)!
         }
@@ -4183,8 +4209,62 @@ struct StateChecks {
         recovering.refresh()
         requests[2].1(accountResponse(false))
         requests[2].2(0, "")
+        precondition(recovering.note == "The move needs attention")
+        func sweepReply(_ model: Model, _ event: String) {
+            let index = requests.count
+            model.checkSweep()
+            requests[index].1(event)
+            requests[index].2(0, "")
+        }
+        let cleanSweep = #"{"swept":true,"ok":true,"complete":true,"receipt":"receipt-one"}"#
+        sweepReply(recovering, #"{"swept":true,"ok":false,"error":"Could not check source","receipt":"receipt-one"}"#)
+        precondition(recovering.note == "The remaining work needs attention")
+        sweepReply(recovering, cleanSweep)
         precondition(recovering.note == "No remaining work" && !recovering.pendingReady)
         precondition(recovering.lines.isEmpty && recovering.to == nil && recovering.from.isEmpty)
+        func failedFinishModel() -> Model {
+            requests = []
+            let model = Model(demo: try! JSONDecoder().decode([Account].self, from: Data(accountResponse(true).utf8)))
+            model.finishPending()
+            requests[0].2(1, "Sign Claude Desktop into Personal")
+            requests[1].1(accountResponse(false))
+            requests[1].2(0, "")
+            return model
+        }
+        for event in [
+            #"{"swept":true,"ok":false,"receipt":"receipt-one"}"#,
+            #"{"swept":true,"ok":true,"complete":true,"receipt":"another-receipt"}"#,
+            #"{"swept":true,"ok":true,"complete":true,"receipt":"receipt-one","failed":[{"id":"fixture","error":"Unmoved history"}]}"#,
+            #"{"swept":true,"ok":true,"complete":true,"receipt":"receipt-one","changed":[{"id":"fixture","fields":["record unavailable"]}]}"#
+        ] {
+            let guarded = failedFinishModel()
+            sweepReply(guarded, event)
+            precondition(guarded.note != "No remaining work")
+            sweepReply(guarded, cleanSweep)
+            precondition(guarded.note == "No remaining work")
+        }
+        let corrupt = failedFinishModel()
+        sweepReply(corrupt, #"{"swept":true,"ok":false,"error":"Corrupt receipt set aside"}"#)
+        sweepReply(corrupt, #"{"swept":true,"ok":true,"complete":true,"receipt":"older-receipt"}"#)
+        precondition(corrupt.note == "The remaining work needs attention")
+        let restart = failedFinishModel()
+        sweepReply(restart, #"{"swept":true,"ok":true,"complete":true,"receipt":"receipt-one","restart":true}"#)
+        let hint = restart.note
+        sweepReply(restart, cleanSweep)
+        precondition(restart.restartAvailable && restart.note == hint)
+        for errors in ["[]", #"[{"id":"fixture","title":"Unmoved session","error":"conflicting history"}]"#] {
+            requests = []
+            let idle = Model(demo: try! JSONDecoder().decode([Account].self, from: Data(accountResponse(true).utf8)))
+            idle.finishPending()
+            requests[0].1("{\"nothing\":true,\"failed\":" + errors + "}")
+            requests[0].2(0, "")
+            requests[1].1(accountResponse(false))
+            requests[1].2(0, "")
+            precondition(idle.badge.isEmpty && idle.visibleCompletion == nil)
+            precondition(idle.note == (errors == "[]" ? "No remaining work" : "1 session was not moved"))
+            precondition(idle.symbol == (errors == "[]" ? "arrow.left.arrow.right" : "info.circle"))
+            precondition(errors == "[]" || idle.lines.contains { $0.1.contains("conflicting history") })
+        }
         requests = []
         let failed = Model(demo: try! JSONDecoder().decode([Account].self, from: Data(accountResponse(true).utf8)))
         failed.finishPending()

--- a/transplant.test.js
+++ b/transplant.test.js
@@ -671,6 +671,49 @@ test('normalize collapses replays and reports conflicts', () => {
   assert.equal(conflict.entries.length, 3)
 })
 
+test('file-read replays keep the full payload and refuse incompatible copies', () => {
+  const parent = entry('assistant', 1, null, SOURCE)
+  const full = entry('user', 2, 1, SOURCE, { toolUseResult: { type: 'text', file: { filePath: '/tmp/fixture.txt', content: 'full file body', numLines: 1 } } })
+  const replay = { ...full, toolUseResult: { ...full.toolUseResult, file: { ...full.toolUseResult.file, content: '' } } }
+  for (const rows of [[parent, full, replay], [parent, replay, full]]) {
+    const result = normalize(rows)
+    assert.equal(result.conflicts, 0)
+    assert.equal(result.replays, 1)
+    assert.deepEqual(result.entries, [parent, full])
+    assert.equal(semantic(rows, SOURCE), semantic([parent, full], SOURCE))
+  }
+  for (const content of ['different file body', null, { text: 'unexpected shape' }]) {
+    const changed = { ...replay, toolUseResult: { ...replay.toolUseResult, file: { ...replay.toolUseResult.file, content } } }
+    assert.equal(normalize([parent, full, changed]).conflicts, 1)
+  }
+  const otherFile = { ...replay, toolUseResult: { ...replay.toolUseResult, file: { ...replay.toolUseResult.file, filePath: '/tmp/other.txt' } } }
+  assert.equal(normalize([parent, full, otherFile]).conflicts, 1)
+})
+
+test('a transcript with a compact file-read replay rehomes intact and is not retired into a poorer fork', async () => {
+  const h = await home()
+  const parent = entry('assistant', 1, null, SOURCE)
+  const full = entry('user', 2, 1, SOURCE, { toolUseResult: { type: 'text', file: { filePath: '/tmp/fixture.txt', content: 'full file body', numLines: 1 } } })
+  const replay = { ...full, toolUseResult: { ...full.toolUseResult, file: { ...full.toolUseResult.file, content: '' } } }
+  await h.write(SOURCE, [parent, full, replay])
+  await h.record('P', SOURCE, rehomeRecord({ title: 'Replayed file read' }))
+  await h.write(id(991), fork([parent, replay], SOURCE, id(991), 'Poorer fork'))
+  await h.record('T', id(991), rehomeRecord({ title: 'Poorer fork' }))
+  const all = await accounts(h.paths), from = all.find(row => row.account === h.acct.P), to = all.find(row => row.account === h.acct.T)
+  const transcript = path.join(h.project, `${SOURCE}.jsonl`)
+  const before = await readFile(transcript), beforeStat = await stat(transcript)
+  const inv = await inventory([from], to, h.paths)
+  assert.equal(inv.blocked.length, 0)
+  assert.equal(inv.there.length, 0)
+  assert.equal(inv.move.length, 1)
+  const moved = await move(inv, to, h.paths)
+  assert.equal(moved.ok, true)
+  assert.equal(moved.receipt.sessions[0].strategy, 'rehome')
+  assert.deepEqual(await readFile(transcript), before)
+  assert.equal((await stat(transcript)).ino, beforeStat.ino)
+  assert.equal((await accounts(h.paths)).find(row => row.account === h.acct.P).sessions.length, 0)
+})
+
 test('semantic change detection keeps richer output and parse state', () => {
   const a = entry('user', 1, null, id(0))
   const plain = entry('user', 2, 1, id(0), { toolUseResult: { stdout: '', stderr: '' } })
@@ -957,6 +1000,25 @@ test('a conflicting same-root history is refused instead of hidden', async () =>
   assert.deepEqual(inv.blocked.map((s) => s.id), [id(937)])
   const result = await move(inv, by[h.acct.Z], h.paths)
   assert.match(result.receipt.failed[0].error, /conflicting duplicate uuids/)
+})
+
+test('Finish reports recorded local failures even after all queued work is complete', async () => {
+  const h = await home()
+  const bad = entry('user', 1, null, SOURCE)
+  await h.write(SOURCE, [bad, { ...bad, message: { role: 'user', content: 'conflicting body' } }])
+  await h.record('P', SOURCE, rehomeRecord({ title: 'Needs attention' }))
+  await h.write(id(994), [entry('user', 2, null, id(994))])
+  await h.record('P', id(994), rehomeRecord({ title: 'Good history' }))
+  const all = await accounts(h.paths), from = all.find(row => row.account === h.acct.P), to = all.find(row => row.account === h.acct.T)
+  const moved = await move(await inventory([from], to, h.paths), to, h.paths)
+  assert.equal(moved.receipt.sessions.length, 1)
+  assert.equal(moved.receipt.failed.length, 1)
+  const result = await cli(h.root, ['finish', '--json'])
+  assert.equal(result.code, 1)
+  const done = lines(result.stdout).find(row => row.done)
+  assert.equal(done.ok, false)
+  assert.match(done.failed[0].error, /conflicting duplicate uuids/)
+  assert.equal(lines(result.stdout).some(row => row.nothing), false)
 })
 
 test('new sidecars remain visible through a shared transcript', async () => {
@@ -4123,6 +4185,15 @@ struct StateChecks {
         requests[2].2(0, "")
         precondition(recovering.note == "No remaining work" && !recovering.pendingReady)
         precondition(recovering.lines.isEmpty && recovering.to == nil && recovering.from.isEmpty)
+        requests = []
+        let failed = Model(demo: try! JSONDecoder().decode([Account].self, from: Data(accountResponse(true).utf8)))
+        failed.finishPending()
+        requests[0].1("{\"done\":true,\"ok\":false,\"complete\":true,\"failed\":[{\"id\":\"fixture\",\"title\":\"Unmoved session\",\"error\":\"conflicting history\"}]}")
+        requests[0].2(1, "")
+        requests[1].1(accountResponse(false))
+        requests[1].2(0, "")
+        precondition(failed.note == "1 need attention")
+        precondition(failed.lines.contains { $0.1.contains("conflicting history") })
         print("Swift queue and metadata states passed")
     }
 }

--- a/transplant.test.js
+++ b/transplant.test.js
@@ -4217,6 +4217,14 @@ struct StateChecks {
             requests[index].2(0, "")
         }
         let cleanSweep = #"{"swept":true,"ok":true,"complete":true,"receipt":"receipt-one"}"#
+        let repeated = Model(demo: Demo.accounts)
+        let repeatError = #"{"swept":true,"ok":false,"error":"Repeated error","receipt":"receipt-one"}"#
+        sweepReply(repeated, repeatError)
+        sweepReply(repeated, repeatError)
+        precondition(repeated.note == "The remaining work needs attention")
+        precondition(repeated.lines.filter { $0.0 == "background" }.count == 1)
+        sweepReply(repeated, cleanSweep)
+        precondition(repeated.note.isEmpty)
         sweepReply(recovering, #"{"swept":true,"ok":false,"error":"Could not check source","receipt":"receipt-one"}"#)
         precondition(recovering.note == "The remaining work needs attention")
         sweepReply(recovering, cleanSweep)


### PR DESCRIPTION
Claude Desktop can persist a file-read result twice with the same UUID, first with its file payload and later with that payload empty. This blocked otherwise intact sessions. Replay normalization and containment now retain the complete payload while rejecting incompatible contents, file paths, payload types, and message bodies. Transcripts are never rewritten, and the analysis cache is invalidated for the updated comparison.

Finish uses the same current Desktop identity as the active badge, with server authentication checks. When no queued work remains, earlier refused sessions are listed as information in both CLI and menubar, with exit 0 and no success animation or notification. Verification failures remain errors and now include their reasons in terminal output. A transient panel error clears only after a successful sweep confirms the same receipt is complete, without unresolved issues, metadata changes, or a restart hint. Account-list absence alone cannot clear it.

Validation:

- All 171 tests and Swift typecheck passed
- Regressions cover stale organization cookies, compact file-read replays, refused-session reporting, verification failures, and corrupt receipts
- Compiled Swift checks cover quiet idle Finish, visible refusal details, missing or failed sweep results, mismatched receipts, preserved restart hints, repeated-error recovery, deduplicated background details, metadata notices, and normal move completion
- Prior live mouse canary on this PR moved the affected session through the installed menubar, removed it from the source sidebar, and opened its full history under the destination
- All ten transcript and supporting files in that canary, 8,520,778 bytes, retained identical contents and inodes
- The canary moved one session with zero failures or held records. Its approved restart took 7.43 seconds

Version remains 4.0.3 and is installed locally for testing. README changes are limited to the Finish description and supported replay behavior. The demo animation is unchanged. No merge or publication has been performed.
