### PR TITLE
Preserve parent and archived fork records during moves

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ Shorter answers:
 - What happens to sessions that are running when I switch? Desktop ends the workers of the account you leave. Sessions with a running worker are held until you approve a restart, or skipped with Move only the rest.
 - Is anything uploaded or read from Keychain? From the CLI, not unless you pass `--cloud`. The menubar's Move always passes it: Desktop's claude.ai session is read from Keychain in memory, sent only to claude.ai to reconcile Remote Control mirrors, and never stored.
 - What about Remote Control and cloud sessions? They stay with the account that created them. `--cloud` archives the source's mirrors after the local copy verifies, and you re-enable Remote Control per session under the new account.
-- Can I undo? Yes. `undo` puts every record back, all or nothing, and refuses if a moved session changed on the target side or is still open.
+- Can I undo? Yes. `undo` puts every record back, all or nothing, and refuses if a moved session changed on the target side, is still open, or a new fork still needs the moved parent.
 - Does the CLI or the VS Code extension have this problem? The CLI does not, `claude --resume` reads the shared transcripts regardless of login. The VS Code extension keeps its own session index, untested and not handled here.
 - What about Claude chats and Projects? Those live on claude.ai per organization and are not touched.
 - Can I do it by hand? Yes. Quit Desktop, move the session's record file into the other account's organization folder, reopen Desktop. Do it only while Desktop is closed, it rewrites records it has open from memory.

--- a/README.md
+++ b/README.md
@@ -78,9 +78,9 @@ To    ↑↓ move · enter confirm
 - without history: transcript no longer exists on disk
 - unreadable: Desktop record is not valid JSON
 - source rejected / target rejected: invalid identity or unsafe transcript history, left untouched
-- compatible source versions: same history in several transcript files, blocked unless the target already holds every version
-- grew apart: overlapping versions with different messages, all move
-- already there: target already holds every message and sidecar file
+- compatible source versions: same history in several transcript files without an explicit Desktop fork, blocked unless the target already holds every version
+- overlapping versions: shared lineage kept separate, including Desktop forks with separate transcripts
+- already there: a compatible Desktop record in the target holds every message and sidecar file
 - held: a Desktop worker owns a required record, restart approval is offered
 - blocked: needs merging, has a collision or unresolved parent, or is owned by a scheduled task, notification route, or external CLI worker
 - retired: source entries moved to quarantine after verification
@@ -103,7 +103,7 @@ Eligibility:
 - history is a single comparable version
 - record filename and identity are valid
 - no scheduled task, notification route, or running worker owns it
-- parent record is already in the target or moves first in the same batch
+- parent record is already in the target or moves first in the same batch, and stays while destination forks refer to it, including archived forks or forks without history
 - no id collision in the target
 
 Worker identity uses the Desktop record id, CLI session id, PID, process start time, and ancestry, plus `~/.claude/sessions/<pid>.json` for workers that omit the session id. External CLI workers are always refused because restarting Desktop does not stop them.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-transplant",
-  "version": "4.0.3",
+  "version": "4.0.4",
   "description": "Move Claude Code history between accounts. Either via menubar or CLI. macOS only.",
   "type": "module",
   "bin": {

--- a/transplant.js
+++ b/transplant.js
@@ -1807,9 +1807,10 @@ async function prepareUndo(receipt, paths) {
 async function finishUndo(receipt, file, paths) {
   const root = path.join(paths.state, 'quarantine')
   const dest = path.join(root, receipt.at)
+  const superseded = receipt.superseded ?? [], undoing = receipt.undoing ?? []
   const problems = [
-    ...await restoreProblems(receipt.superseded ?? [], root),
-    ...await restoreProblems(receipt.undoing ?? [], root),
+    ...await restoreProblems(superseded, root),
+    ...await restoreProblems(undoing, root),
     ...await activationProblems(receipt)
   ]
   if (await exists(path.join(dest, 'receipt.json'))) problems.push('undo receipt path occupied')
@@ -1820,10 +1821,29 @@ async function finishUndo(receipt, file, paths) {
   }
   problems.push(...await undoParentProblems(receipt))
   if (problems.length) return { receipt, restoreProblems: problems }
-  await restore(receipt.superseded ?? [], root)
-  await park(receipt.undoing ?? [])
-  await restoreActivations(receipt)
-  await mkdir(dest, { recursive: true })
+  let failure
+  try {
+    await restore(superseded, root)
+    await park(undoing)
+    await restoreActivations(receipt)
+    await mkdir(dest, { recursive: true })
+  } catch (error) { failure = error }
+  problems.push(...await undoParentProblems(receipt))
+  if (!problems.length && failure) throw failure
+  if (problems.length) {
+    if (failure) problems.push(failure.message)
+    const blocked = []
+    for (const item of undoing) {
+      const unsafe = await restoreProblems([item], root)
+      blocked.push(...unsafe)
+      if (!unsafe.length) {
+        try { await restore([item], root) }
+        catch (error) { blocked.push(`Undo rollback blocked: ${error.message}`) }
+      }
+    }
+    blocked.push(...await restoreProblems(undoing, root), ...await restoreProblems(superseded, root))
+    return { receipt, restoreProblems: [...new Set([...problems, ...blocked])] }
+  }
   await rename(file, path.join(dest, 'receipt.json'))
   return { receipt, dest }
 }

--- a/transplant.js
+++ b/transplant.js
@@ -1204,8 +1204,10 @@ async function cloudInventory(cloud, from, targets, move, cache, report, cutoff 
       })
       const eligible = remoteConversation.length >= 4 ? candidates : [...new Set([...named, ...linked])]
       const covered = findCovered(eligible)
-      if (covered.length > 1) return { blocked: { id: session.id, title: session.title, account, error: 'multiple verified local target histories' } }
-      if (covered.length === 1) return { match: { session, target: covered[0], conversationSha: sha(stable(remoteConversation)), account } }
+      const linkedCovered = covered.filter(candidate => candidate.remoteIds.has(sessionId))
+      const verified = linkedCovered.length === 1 ? linkedCovered : covered
+      if (verified.length > 1) return { blocked: { id: session.id, title: session.title, account, error: 'multiple verified local target histories' } }
+      if (verified.length === 1) return { match: { session, target: verified[0], conversationSha: sha(stable(remoteConversation)), account } }
       if (remoteConversation.length < 4 && findCovered(candidates.filter((candidate) => !eligible.includes(candidate))).length) return { blocked: { id: session.id, title: session.title, account, error: 'remote history is too short to match a renamed local target' } }
       const anchors = linked.length ? linked : named
       if (anchors.length !== 1) return { blocked: { id: session.id, title: session.title, account, error: anchors.length ? 'multiple divergent local targets' : 'no linked or same-title local target' } }
@@ -2059,7 +2061,7 @@ const owners = (sources, carried) => {
   return sources.map(s => ({ s, owner: candidates.get(s.roots.values().next().value)?.find(carrier => included(s, carrier.history)) })).filter(row => row.owner)
 }
 
-async function retire(inv, receipt, paths, at, problems, save, report = () => {}, check = () => {}) {
+async function retire(inv, to, receipt, paths, at, problems, save, report = () => {}, check = () => {}) {
   check(true)
   report('retire', 'checking', { live: true })
   const bad = new Set(problems.map((p) => p.id))
@@ -2070,6 +2072,7 @@ async function retire(inv, receipt, paths, at, problems, save, report = () => {}
     const history = bad.has(row.targetId) ? null : inv.move.find((m) => m.id === row.id)
     if (history) landed.push({ by: row.targetId, history })
   }
+  const requiredParents = new Set([...to.sessions, ...inv.move].map(row => desktopRecordOf(row).forkedFromSessionId).filter(Boolean))
   const gone = new Set()
   const blocked = new Set()
   const sourceRows = new Map()
@@ -2082,7 +2085,7 @@ async function retire(inv, receipt, paths, at, problems, save, report = () => {}
   }
   for (const { by, history } of landed) {
     for (const t of inv.targets) {
-      if (gone.has(t) || !t.transcript || !included(t, history)) continue
+      if (gone.has(t) || requiredParents.has(t.record) || !t.transcript || !included(t, history)) continue
       const claim = ownership(t, liveWorkers)
       if (claim) {
         if (!blocked.has(t.session.file)) receipt.failed.push({ id: t.id, title: t.session.title, error: `${claim} kept in destination` })
@@ -2770,7 +2773,7 @@ async function transfer(inv, to, paths, report, context = {}) {
   const priorProblems = context.existing ? receipt.appendCheckpoint.verification?.problems ?? [] : []
   receipt.verification = { ok: ok && receipt.appendCheckpoint?.verification?.ok !== false && !priorProblems.length, problems: [...priorProblems, ...recordedProblems] }
   await save()
-  await retire(inv, receipt, paths, at, problems, save, report, context.check)
+  await retire(inv, to, receipt, paths, at, problems, save, report, context.check)
   if (inv.cloudRequested) {
     const current = await accounts(paths)
     const actual = receipt.fromAccounts.filter((source) => localCloudPending(current.find((account) => sameAccount(account, source))))
@@ -3749,7 +3752,7 @@ async function main(argv) {
       sourceRejected ? `${count(sourceRejected)} source rejected` : null,
       targetRejected ? `${count(targetRejected)} target rejected` : null,
       inv.twice ? `${count(inv.twice)} compatible source versions` : null,
-      inv.apart ? `${count(inv.apart)} grew apart, all kept` : null,
+      inv.apart ? `${count(inv.apart)} overlapping versions, kept separate` : null,
       inv.there.length ? `${count(inv.there.length)} already there` : null,
       inv.blocked.length ? `${count(inv.blocked.length)} blocked` : null,
       inv.cloud?.matches.length ? `${count(inv.cloud.matches.length)} cloud mirrors` : null,

--- a/transplant.js
+++ b/transplant.js
@@ -1109,9 +1109,10 @@ const sameEvents = (a, b) => {
 }
 const historyIncluded = (a, b) => a.comparable && b.comparable && a.roots.isSubsetOf(b.roots) && a.state === b.state && sameEvents(a, b)
 const carries = (a, b) => Boolean(a.sidecar && b.sidecar && a.sidecar.set.isSubsetOf(b.sidecar.set))
-const included = (a, b) => historyIncluded(a, b) && carries(a, b)
-const progress = (report, stage, completed, total) => report(stage, `${completed}/${total}`, { live: true, completed, total })
 const desktopRecordOf = (row) => row.session?.record ?? row.record ?? {}
+const canShareRecord = (a, b) => a.transcript === b.transcript || !(desktopRecordOf(a).forkedFromSessionId || desktopRecordOf(b).forkedFromSessionId)
+const included = (a, b) => canShareRecord(a, b) && historyIncluded(a, b) && carries(a, b)
+const progress = (report, stage, completed, total) => report(stage, `${completed}/${total}`, { live: true, completed, total })
 const desktopFileOf = (row) => typeof row === 'string' ? row : row.session?.file ?? row.file
 const bridgeIdsOf = (row) => [row, ...(row.members ?? [])].flatMap((member) => {
   const record = desktopRecordOf(member)
@@ -1347,7 +1348,7 @@ export async function inventory(from, to, paths, report = () => {}, options = {}
   for (const source of ranked) {
     const at = reps.findIndex((candidate) => {
       if (!historyIncluded(source, candidate) && !historyIncluded(candidate, source)) return false
-      return candidate.members.every((member) => sidecarsAgree(member.sidecar, source.sidecar))
+      return candidate.members.every((member) => canShareRecord(member, source) && sidecarsAgree(member.sidecar, source.sidecar))
     })
     if (at >= 0) {
       const prior = reps[at]

--- a/transplant.js
+++ b/transplant.js
@@ -211,9 +211,13 @@ export async function restartPlan(inv, paths, table = processTable(paths.claudeA
   let added = true
   while (added && inv) {
     added = false
-    for (const source of released) {
-      const parent = held.find((item) => item.sources.some((member) => inv.sources.find((row) => row.file === member.file)?.record.sessionId === source.record.forkedFromSessionId))
-      if (parent) added = add(source, source, parent.workers) || added
+    for (const source of [...released, ...inv.there]) {
+      const related = held.find((item) => item.sources.some((member) => {
+        const current = inv.sources.find((row) => row.file === member.file)
+        return current && (source.members ?? [source]).some((row) => sameAccount(row.account, current.account) &&
+          (row.record.forkedFromSessionId === current.record.sessionId || current.record.forkedFromSessionId === row.record.sessionId))
+      }))
+      if (related) added = add(source, source, related.workers) || added
     }
   }
   if (inv && !held.length) return null
@@ -1814,6 +1818,7 @@ async function finishUndo(receipt, file, paths) {
     if (ownsWorker(liveWorkers, row.targetId, row.targetRecordId)) problems.push(`${row.title} | running worker kept in destination`)
     if (row.taskFile && (await taskSessions(row.taskFile)).has(row.targetRecordId ?? `local_${row.targetId}`) !== row.taskOwned) problems.push(`${row.title} | scheduled tasks changed`)
   }
+  problems.push(...await undoParentProblems(receipt))
   if (problems.length) return { receipt, restoreProblems: problems }
   await restore(receipt.superseded ?? [], root)
   await park(receipt.undoing ?? [])
@@ -1921,6 +1926,8 @@ async function reconcileFiles(paths, options = {}) {
   receipt.failed ??= []
   receipt.superseded ??= []
   if (receipt.undoing) {
+    const blocked = await undoParentProblems(receipt)
+    if (blocked.length) return { title: 'undo recovery blocked', error: blocked.join(', '), problems: blocked }
     const remote = await restoreRemote(receipt, p.file, paths, options.cloud)
     if (remote.problems.length) return { title: 'Remote Control undo recovery blocked', error: remote.problems.join(', '), problems: remote.problems }
     if (remote.pending.length) return { title: 'Undo pending', error: `sign Claude Desktop into ${remote.pending.join(' or ')}`, pendingUndo: remote.pending, remoteRestored: remote.restored, receipt }
@@ -2070,12 +2077,21 @@ const owners = (sources, carried) => {
 async function parentReferences(directories) {
   const parents = new Map()
   for (const dir of directories) for (const file of await recordFiles(dir)) {
-    const record = await readJson(file)
+    const record = await readJson(file).catch(() => null)
     if (!record || typeof record !== 'object' || Array.isArray(record)) throw new Error(`unreadable Desktop record: ${file}`)
     const parent = record.forkedFromSessionId
     parents.set(file, LOCAL_RECORD.test(parent ?? '') ? path.join(dir, `${parent}.json`) : null)
   }
   return parents
+}
+
+async function undoParentProblems(receipt) {
+  const removing = new Set(receipt.sessions.map(row => row.record))
+  try {
+    const parents = await parentReferences(new Set([...removing].map(file => path.dirname(file))))
+    return [...parents].filter(([file, parent]) => !removing.has(file) && removing.has(parent))
+      .map(([file]) => `${path.basename(file)} | parent Desktop record would be removed by Undo`)
+  } catch (error) { return [error.message] }
 }
 
 async function retire(inv, to, receipt, paths, at, problems, save, report = () => {}, check = () => {}) {
@@ -3297,6 +3313,7 @@ export function undo(paths, options = {}) {
     }
     if (changedAfterSnapshot.length) return { receipt, changed: changedAfterSnapshot }
     const activationBlocked = await activationProblems(receipt)
+    activationBlocked.push(...await undoParentProblems(receipt))
     if (activationBlocked.length) return { receipt, restoreProblems: activationBlocked }
     receipt.undoing = plan
     if (receipt.remote?.length) receipt.remoteUndoing = structuredClone(receipt.remote)

--- a/transplant.test.js
+++ b/transplant.test.js
@@ -3347,6 +3347,73 @@ test('same-account rehome preserves a parent link when both records move', async
   assert.deepEqual((await readdir(h.project)).sort(), [`${SOURCE}.jsonl`, `${child}.jsonl`].sort())
 })
 
+test('compatible Desktop parent and archived fork move separately and undo without changing history', async () => {
+  for (const richer of ['parent', 'fork']) {
+    const h = await home(), child = id(777)
+    const targetDir = path.join(h.paths.records, h.acct.P, h.org.T)
+    await mkdir(targetDir, { recursive: true })
+    const base = [entry('user', 1, null, SOURCE), entry('assistant', 2, 1, SOURCE)]
+    const branch = fork(base, SOURCE, child, 'Archived fork')
+    await h.write(SOURCE, richer === 'parent' ? [...base, entry('user', 3, 2, SOURCE)] : base)
+    await h.write(child, richer === 'fork' ? [...branch, entry('user', 4, null, child)] : branch)
+    await h.record('P', SOURCE, rehomeRecord({ title: 'Parent', isArchived: false, isStarred: true }))
+    await h.record('P', child, rehomeRecord({ title: 'Archived fork', isArchived: true, forkedFromSessionId: `local_${SOURCE}` }))
+    const files = []
+    for (const sid of [SOURCE, child]) {
+      await mkdir(path.join(h.project, sid), { recursive: true })
+      const sidecar = path.join(h.project, sid, `${sid}.txt`)
+      await writeFile(sidecar, `supporting data for ${sid}`)
+      for (const file of [path.join(h.project, `${sid}.jsonl`), sidecar]) files.push({ file, bytes: await readFile(file), inode: (await stat(file)).ino })
+    }
+    const originalRecords = await Promise.all([SOURCE, child].map(sid => readFile(path.join(h.dir('P'), `local_${sid}.json`))))
+    const all = await accounts(h.paths), from = all.find(row => row.account === h.acct.P && row.org === h.org.P), to = all.find(row => row.account === h.acct.P && row.org === h.org.T)
+    const inv = await inventory([from], to, h.paths)
+    assert.deepEqual(inv.blocked.map(row => row.error), [])
+    assert.deepEqual(inv.move.map(row => row.id), [SOURCE, child])
+    const moved = await move(inv, to, h.paths)
+    assert.equal(moved.ok, true)
+    assert.equal(moved.receipt.sessions.length, 2)
+    assert.equal(moved.receipt.sessions.every(row => row.strategy === 'rehome'), true)
+    assert.deepEqual(await readdir(h.dir('P')), [])
+    const parent = JSON.parse(await readFile(path.join(targetDir, `local_${SOURCE}.json`)))
+    const archived = JSON.parse(await readFile(path.join(targetDir, `local_${child}.json`)))
+    assert.equal(parent.title, 'Parent')
+    assert.equal(parent.isStarred, true)
+    assert.equal(parent.isArchived, false)
+    assert.equal(archived.title, 'Archived fork')
+    assert.equal(archived.isArchived, true)
+    assert.equal(archived.forkedFromSessionId, parent.sessionId)
+    for (const file of files) {
+      assert.deepEqual(await readFile(file.file), file.bytes)
+      assert.equal((await stat(file.file)).ino, file.inode)
+    }
+    const restored = await undo(h.paths)
+    assert.ok(restored.dest)
+    assert.deepEqual(await readdir(targetDir), [])
+    for (const [index, sid] of [SOURCE, child].entries()) assert.deepEqual(await readFile(path.join(h.dir('P'), `local_${sid}.json`)), originalRecords[index])
+  }
+})
+
+test('a Desktop fork is preserved when its parent already covers its history in the destination', async () => {
+  const h = await home(), child = id(777)
+  const base = [entry('user', 1, null, SOURCE), entry('assistant', 2, 1, SOURCE)]
+  await h.write(SOURCE, base)
+  await h.write(child, fork(base, SOURCE, child, 'Archived fork'))
+  await h.record('T', SOURCE, rehomeRecord({ title: 'Parent' }))
+  await h.record('P', child, rehomeRecord({ title: 'Archived fork', isArchived: true, forkedFromSessionId: `local_${SOURCE}` }))
+  const all = await accounts(h.paths), from = all.find(row => row.account === h.acct.P), to = all.find(row => row.account === h.acct.T)
+  const inv = await inventory([from], to, h.paths)
+  assert.equal(inv.there.length, 0)
+  assert.deepEqual(inv.move.map(row => row.id), [child])
+  const moved = await move(inv, to, h.paths)
+  assert.equal(moved.ok, true)
+  assert.equal(moved.receipt.superseded.some(row => !row.source), false)
+  assert.deepEqual((await readdir(h.dir('T'))).sort(), [`local_${SOURCE}.json`, `local_${child}.json`].sort())
+  const archived = JSON.parse(await readFile(path.join(h.dir('T'), `local_${child}.json`)))
+  assert.equal(archived.isArchived, true)
+  assert.equal(archived.forkedFromSessionId, `local_${SOURCE}`)
+})
+
 test('progress begins before analysis and every counted phase reaches its total', async () => {
   const h = await home()
   const teamDir = path.join(h.paths.records, h.acct.P, h.org.T)

--- a/transplant.test.js
+++ b/transplant.test.js
@@ -3587,23 +3587,193 @@ test('source parent retention follows ancestry within the affected account', asy
   }
 })
 
-test('a held source fork keeps its parent through continuation and Undo', async () => {
-  const h = await home(), child = id(777), base = branchEntries(2, SOURCE, 1)
+test('held forks move and retire their parents through Finish, sweep, and Undo', async () => {
+  for (const present of [false, true]) for (const continuation of [finishHeld, finishWorkflow, sweep]) {
+    const h = await home(), child = id(777), cold = id(778), later = id(779), base = branchEntries(2, SOURCE, 1)
+    await h.write(SOURCE, base)
+    await h.record('P', SOURCE, rehomeRecord())
+    await h.write(child, fork(base, SOURCE, child, 'Fork'))
+    await h.record('P', child, rehomeRecord({ forkedFromSessionId: `local_${SOURCE}` }))
+    await h.write(cold, branchEntries(2, cold, 300))
+    await h.record('P', cold, rehomeRecord())
+    if (present) await h.record('T', SOURCE, rehomeRecord())
+    const originalParent = present ? await readFile(path.join(h.dir('T'), `local_${SOURCE}.json`)) : null
+    const all = await accounts(h.paths), from = all.find(row => row.account === h.acct.P), to = all.find(row => row.account === h.acct.T)
+    const originals = await Promise.all(from.sessions.map(async row => [row.file, await readFile(row.file)]))
+    const moved = await executeMove([from], to, h.paths, { processes: desktopFixture(child), moveOnly: true })
+    assert.equal(moved.ok, true)
+    assert.equal(moved.complete, false)
+    assert.deepEqual(moved.receipt.held.map(row => row.id), [child, SOURCE])
+    assert.deepEqual(moved.receipt.sessions.map(row => row.id), [cold])
+    assert.deepEqual(moved.receipt.failed, [])
+    assert.deepEqual((await readdir(h.dir('P'))).sort(), [SOURCE, child].map(sid => `local_${sid}.json`).sort())
+    assert.deepEqual((await readdir(h.dir('T'))).sort(), [cold, ...(present ? [SOURCE] : [])].map(sid => `local_${sid}.json`).sort())
+    await h.write(later, branchEntries(2, later, 400))
+    await h.record('P', later, rehomeRecord())
+    const result = await continuation(h.paths, { processes: [] }), finished = result.result ?? result
+    assert.equal(finished.file, moved.file)
+    assert.equal(finished.receipt.at, moved.receipt.at)
+    assert.equal(finished.ok, true)
+    assert.equal(finished.complete, true)
+    assert.deepEqual(finished.receipt.held, [])
+    assert.deepEqual(finished.receipt.failed, [])
+    assert.deepEqual(await readdir(h.dir('P')), [`local_${later}.json`])
+    assert.deepEqual((await readdir(h.dir('T'))).sort(), [SOURCE, child, cold].map(sid => `local_${sid}.json`).sort())
+    assert.equal((await sweep(h.paths, { processes: [] })).complete, true)
+    const undone = await undo(h.paths)
+    assert.ok(undone.dest)
+    assert.equal(JSON.parse(await readFile(path.join(undone.dest, 'receipt.json'))).at, moved.receipt.at)
+    assert.deepEqual(await readdir(h.dir('T')), present ? [`local_${SOURCE}.json`] : [])
+    if (present) assert.deepEqual(await readFile(path.join(h.dir('T'), `local_${SOURCE}.json`)), originalParent)
+    for (const [file, bytes] of originals) assert.deepEqual(await readFile(file), bytes)
+    assert.ok(await readFile(path.join(h.dir('P'), `local_${later}.json`)))
+  }
+})
+
+test('held fork families include ancestors and siblings only in the same source account and org', async () => {
+  for (const sameLogin of [false, true]) {
+    const h = await home(), parent = id(776), child = id(777), sibling = id(778), other = id(779), base = branchEntries(2, SOURCE, 1)
+    if (sameLogin) { h.acct.Q = h.acct.P; await mkdir(h.dir('Q'), { recursive: true }) }
+    const parentEntries = fork(base, SOURCE, parent, 'Parent')
+    for (const [sid, entries, forkedFromSessionId] of [
+      [SOURCE, base, null],
+      [parent, parentEntries, `local_${SOURCE}`],
+      [child, fork(parentEntries, parent, child, 'Child'), `local_${parent}`],
+      [sibling, fork(parentEntries, parent, sibling, 'Sibling'), `local_${parent}`]
+    ]) {
+      await h.write(sid, entries)
+      await h.record('P', sid, rehomeRecord({ forkedFromSessionId }))
+    }
+    await h.record('T', SOURCE, rehomeRecord())
+    await h.write(other, fork(base, SOURCE, other, 'Other source fork'))
+    await h.record('Q', other, rehomeRecord({ forkedFromSessionId: `local_${SOURCE}` }))
+    const all = await accounts(h.paths), from = all.filter(row => [h.org.P, h.org.Q].includes(row.org)), to = all.find(row => row.account === h.acct.T)
+    const originals = await Promise.all(from.flatMap(row => row.sessions).map(async row => [row.file, await readFile(row.file)]))
+    const table = [...desktopFixture(child), { ...desktopFixture(id(888))[1], pid: 502, started: 'collateral' }]
+    const plan = await restartPlan(await inventory(from, to, h.paths, () => {}, { processes: table }), h.paths, table)
+    assert.deepEqual(new Set(plan.held.map(row => row.id)), new Set([SOURCE, parent, child, sibling]))
+    assert.deepEqual(plan.interrupts.map(row => row.pid), [502])
+    assert.ok(plan.held.every(row => row.workers.length === 1 && row.workers[0].pid === 501 && row.sources.every(source => source.account === h.acct.P && source.org === h.org.P)))
+    const moved = await executeMove(from, to, h.paths, { processes: table, moveOnly: true })
+    assert.equal(moved.ok, true)
+    assert.deepEqual(moved.receipt.sessions.map(row => row.id), [other])
+    assert.deepEqual(await readdir(h.dir('Q')), [])
+    const finished = await finishHeld(h.paths, { processes: [] })
+    assert.equal(finished.ok, true)
+    assert.equal(finished.complete, true)
+    assert.deepEqual(await readdir(h.dir('P')), [])
+    assert.ok((await undo(h.paths)).dest)
+    for (const [file, bytes] of originals) assert.deepEqual(await readFile(file), bytes)
+    assert.deepEqual(await readdir(h.dir('T')), [`local_${SOURCE}.json`])
+  }
+})
+
+test('unreadable Desktop metadata stops retirement and preserves recoverable source and destination records', async () => {
+  const h = await home(), child = id(777), corrupt = id(778), base = branchEntries(2, SOURCE, 1)
   await h.write(SOURCE, base)
   await h.record('P', SOURCE, rehomeRecord())
   await h.write(child, fork(base, SOURCE, child, 'Fork'))
   await h.record('P', child, rehomeRecord({ forkedFromSessionId: `local_${SOURCE}` }))
   const all = await accounts(h.paths), from = all.find(row => row.account === h.acct.P), to = all.find(row => row.account === h.acct.T)
-  const moved = await executeMove([from], to, h.paths, { processes: desktopFixture(child), moveOnly: true })
-  assert.deepEqual(moved.receipt.held.map(row => row.id), [child])
-  assert.deepEqual(moved.receipt.failed, [])
-  assert.deepEqual((await readdir(h.dir('P'))).sort(), [SOURCE, child].map(sid => `local_${sid}.json`).sort())
-  const finished = await finishHeld(h.paths, { processes: [] })
-  assert.equal(finished.ok, true)
-  assert.deepEqual(await readdir(h.dir('P')), [`local_${SOURCE}.json`])
+  const originals = await Promise.all(from.sessions.map(async row => [row.file, await readFile(row.file)]))
+  const inv = await inventory([from], to, h.paths)
+  const corruptFile = path.join(h.dir('P'), `local_${corrupt}.json`)
+  await writeFile(corruptFile, '{broken')
+  const moved = await move(inv, to, h.paths)
+  assert.equal(moved.ok, false)
+  assert.match(moved.receipt.failed.at(-1).error, /unreadable Desktop record:/)
+  assert.deepEqual(moved.receipt.superseded, [])
+  assert.equal(moved.receipt.retiring, null)
+  assert.equal(moved.receipt.sessions.length, 2)
+  for (const [file, bytes] of originals) {
+    assert.deepEqual(await readFile(file), bytes)
+    assert.equal(JSON.parse(await readFile(path.join(h.dir('T'), path.basename(file)))).sessionId, JSON.parse(bytes).sessionId)
+  }
+  assert.equal((await sweep(h.paths, { processes: [] })).complete, false)
+  await unlink(corruptFile)
   assert.ok((await undo(h.paths)).dest)
+  for (const [file, bytes] of originals) assert.deepEqual(await readFile(file), bytes)
   assert.deepEqual(await readdir(h.dir('T')), [])
-  assert.deepEqual((await readdir(h.dir('P'))).sort(), [SOURCE, child].map(sid => `local_${sid}.json`).sort())
+})
+
+test('Undo refuses new destination forks before cloud or local changes and on every recovery entry', async () => {
+  for (const staged of [false, true]) for (const unreadable of [false, true]) {
+    const h = await home(), child = id(777), cold = id(778), base = branchEntries(2, SOURCE, 1)
+    await h.write(SOURCE, base)
+    await h.record('P', SOURCE, rehomeRecord({ title: 'Parent' }))
+    await h.write(cold, branchEntries(2, cold, 300))
+    await h.record('P', cold, rehomeRecord())
+    const calls = []
+    let status = 'active'
+    const cloud = cloudFixture(h, {
+      list: async () => [remoteSession({ id: 'cse_undo_parent', title: 'Parent', status })],
+      eventRows: async () => remoteRows(base),
+      session: async () => { calls.push('session'); return remoteState(status) },
+      archive: async () => { calls.push('archive'); status = 'archived' },
+      unarchive: async () => { calls.push('unarchive'); status = 'active' }
+    })
+    const all = await accounts(h.paths), from = all.find(row => row.account === h.acct.P), to = all.find(row => row.account === h.acct.T)
+    const originals = await Promise.all(from.sessions.map(async row => [row.file, await readFile(row.file)]))
+    const moved = await move(await inventory([from], to, h.paths, () => {}, { cloud }), to, h.paths)
+    assert.equal(moved.ok, true)
+    assert.equal(status, 'archived')
+    if (staged) assert.deepEqual((await undo(h.paths, { cloud: { ...cloud, account: h.acct.Q, org: h.org.Q } })).pendingUndo, [from.label])
+    const childFile = path.join(h.dir('T'), `local_${child}.json`)
+    if (unreadable) await writeFile(childFile, '{broken')
+    else await h.record('T', child, rehomeRecord({ isArchived: true, forkedFromSessionId: `local_${SOURCE}` }))
+    const receiptBytes = await readFile(moved.file)
+    const destination = await Promise.all((await readdir(h.dir('T'))).map(async name => [path.join(h.dir('T'), name), await readFile(path.join(h.dir('T'), name))]))
+    calls.length = 0
+    for (const operation of staged ? [undo, finishPending, finishWorkflow, sweep] : [undo]) {
+      const result = await operation(h.paths, { cloud, processes: [] })
+      const problems = result.restoreProblems ?? (result.reconciled ?? result.recovered)?.problems
+      assert.match(problems[0], unreadable ? /unreadable Desktop record:/ : /parent Desktop record would be removed by Undo/)
+      assert.equal(result.dest, undefined)
+      assert.deepEqual(calls, [])
+      assert.equal(status, 'archived')
+      assert.deepEqual(await readFile(moved.file), receiptBytes)
+      assert.deepEqual(await readdir(h.dir('P')), [])
+      for (const [file, bytes] of destination) assert.deepEqual(await readFile(file), bytes)
+    }
+    await unlink(childFile)
+    const undone = await undo(h.paths, { cloud })
+    assert.ok(undone.dest)
+    assert.equal(status, 'active')
+    for (const [file, bytes] of originals) assert.deepEqual(await readFile(file), bytes)
+    assert.deepEqual(await readdir(h.dir('T')), [])
+  }
+})
+
+test('Undo rechecks destination forks after cloud restoration before removing any local record', async () => {
+  const h = await home(), child = id(777), base = branchEntries(2, SOURCE, 1)
+  await h.write(SOURCE, base)
+  await h.record('P', SOURCE, rehomeRecord({ title: 'Parent' }))
+  let status = 'active'
+  const cloud = cloudFixture(h, {
+    list: async () => [remoteSession({ id: 'cse_undo_parent', title: 'Parent', status })],
+    eventRows: async () => remoteRows(base),
+    session: async () => remoteState(status),
+    archive: async () => { status = 'archived' },
+    unarchive: async () => {
+      await h.record('T', child, rehomeRecord({ forkedFromSessionId: `local_${SOURCE}` }))
+      status = 'active'
+    }
+  })
+  const all = await accounts(h.paths), from = all.find(row => row.account === h.acct.P), to = all.find(row => row.account === h.acct.T)
+  const moved = await move(await inventory([from], to, h.paths, () => {}, { cloud }), to, h.paths)
+  assert.equal(moved.ok, true)
+  const parentFile = path.join(h.dir('T'), `local_${SOURCE}.json`), parentBytes = await readFile(parentFile)
+  const refused = await undo(h.paths, { cloud })
+  assert.match(refused.restoreProblems[0], /parent Desktop record would be removed by Undo/)
+  assert.equal(status, 'active')
+  assert.deepEqual(await readFile(parentFile), parentBytes)
+  assert.deepEqual((await readdir(h.dir('T'))).sort(), [SOURCE, child].map(sid => `local_${sid}.json`).sort())
+  assert.deepEqual(await readdir(h.dir('P')), [])
+  assert.ok(JSON.parse(await readFile(moved.file)).undoing)
+  await unlink(path.join(h.dir('T'), `local_${child}.json`))
+  assert.ok((await undo(h.paths, { cloud })).dest)
+  assert.ok(await readFile(path.join(h.dir('P'), `local_${SOURCE}.json`)))
+  assert.deepEqual(await readdir(h.dir('T')), [])
 })
 
 test('destination parents survive forks added after inventory or during final preparation', async () => {

--- a/transplant.test.js
+++ b/transplant.test.js
@@ -2637,6 +2637,69 @@ test('a verified target archives its source Remote Control mirror and Undo resto
   assert.deepEqual(restored.promptAppendSnapshot, activated.promptAppendSnapshot)
 })
 
+test('a unique bridge link selects a fully verified Desktop fork and Undo restores its archive state', async () => {
+  for (const location of ['P', 'T']) {
+    const h = await home(), child = id(777), base = branchEntries(4, SOURCE, 1)
+    await h.write(SOURCE, base)
+    await h.record('T', SOURCE, rehomeRecord({ title: 'Parent', isArchived: true }))
+    await h.write(child, [...fork(base, SOURCE, child, 'Fork'), { type: 'bridge-session', sessionId: child, bridgeSessionId: 'cse_linked_fork' }])
+    await h.record(location, child, rehomeRecord({ title: 'Fork', isArchived: true, forkedFromSessionId: `local_${SOURCE}`, bridgeSessionIds: ['session_linked_fork'] }))
+    const parentFile = path.join(h.dir('T'), `local_${SOURCE}.json`), targetFile = path.join(h.dir('T'), `local_${child}.json`)
+    const originalParent = await readFile(parentFile), originalFork = JSON.parse(await readFile(path.join(h.dir(location), `local_${child}.json`)))
+    let status = 'active'
+    const cloud = cloudFixture(h, {
+      list: async () => [remoteSession({ id: 'cse_linked_fork', title: 'Renamed remote fork', status })],
+      eventRows: async () => remoteRows(base),
+      session: async () => remoteState(status),
+      archive: async () => { assert.ok(await readFile(targetFile)); status = 'archived' },
+      unarchive: async () => { status = 'active' }
+    })
+    const all = await accounts(h.paths), from = all.find(row => row.account === h.acct.P), to = all.find(row => row.account === h.acct.T)
+    const inv = await inventory([from], to, h.paths, () => {}, { cloud })
+    assert.deepEqual(inv.cloud.blocked, [])
+    assert.deepEqual(inv.cloud.matches.map(row => [row.target.kind, row.target.id]), [[location === 'P' ? 'move' : 'existing', child]])
+    const moved = await move(inv, to, h.paths)
+    assert.equal(moved.ok, true)
+    assert.equal(status, 'archived')
+    assert.deepEqual(moved.receipt.remote.map(row => row.targetId), [child])
+    assert.deepEqual(await readdir(h.dir('P')), [])
+    const placed = JSON.parse(await readFile(targetFile))
+    assert.equal(placed.isArchived, false)
+    assert.equal(placed.forkedFromSessionId, `local_${SOURCE}`)
+    assert.deepEqual(placed.bridgeSessionIds, location === 'P' ? [] : ['session_linked_fork'])
+    assert.deepEqual(await readFile(parentFile), originalParent)
+    assert.ok((await undo(h.paths, { cloud })).dest)
+    assert.equal(status, 'active')
+    assert.deepEqual(await readFile(parentFile), originalParent)
+    assert.deepEqual(JSON.parse(await readFile(path.join(h.dir(location), `local_${child}.json`))), originalFork)
+  }
+})
+
+test('overlapping verified histories refuse absent, ambiguous, or unverified bridge links', async () => {
+  for (const links of ['none', 'multiple', 'unverified']) {
+    const h = await home(), child = id(777), base = branchEntries(4, SOURCE, 1)
+    const bridgeSessionIds = links === 'multiple' ? ['session_linked_fork'] : []
+    await h.write(SOURCE, base)
+    await h.record('T', SOURCE, rehomeRecord({ bridgeSessionIds }))
+    await h.write(child, fork(base, SOURCE, child, 'Fork'))
+    await h.record('P', child, rehomeRecord({ forkedFromSessionId: `local_${SOURCE}`, bridgeSessionIds }))
+    if (links === 'unverified') {
+      const shorter = id(778)
+      await h.write(shorter, fork(base.slice(0, 3), SOURCE, shorter, 'Shorter fork'))
+      await h.record('T', shorter, rehomeRecord({ forkedFromSessionId: `local_${SOURCE}`, bridgeSessionIds: ['session_linked_fork'] }))
+    }
+    const cloud = cloudFixture(h, {
+      list: async () => [remoteSession({ id: 'cse_linked_fork', title: 'Remote fork' })],
+      eventRows: async () => remoteRows(base)
+    })
+    const all = await accounts(h.paths), from = all.find(row => row.account === h.acct.P), to = all.find(row => row.account === h.acct.T)
+    const inv = await inventory([from], to, h.paths, () => {}, { cloud })
+    assert.deepEqual(inv.cloud.matches, [])
+    assert.equal(inv.cloud.blocked.length, 1)
+    assert.match(inv.cloud.blocked[0].error, /multiple .*local target/)
+  }
+})
+
 test('attachment prompts and tiny ordering drift prove semantic Remote Control containment', async () => {
   const h = await home()
   const remote = Array.from({ length: 100 }, (_, index) => entry(index % 2 ? 'assistant' : 'user', index + 100, index ? index + 99 : null, SOURCE))
@@ -3408,10 +3471,51 @@ test('a Desktop fork is preserved when its parent already covers its history in 
   const moved = await move(inv, to, h.paths)
   assert.equal(moved.ok, true)
   assert.equal(moved.receipt.superseded.some(row => !row.source), false)
+  assert.deepEqual(await readdir(h.dir('P')), [])
   assert.deepEqual((await readdir(h.dir('T'))).sort(), [`local_${SOURCE}.json`, `local_${child}.json`].sort())
   const archived = JSON.parse(await readFile(path.join(h.dir('T'), `local_${child}.json`)))
   assert.equal(archived.isArchived, true)
   assert.equal(archived.forkedFromSessionId, `local_${SOURCE}`)
+})
+
+test('destination parents survive richer replacements while Desktop forks still refer to them', async () => {
+  for (const location of ['source', 'destination', 'without history']) for (const isArchived of [false, true]) {
+    const h = await home(), richer = id(776), child = id(777)
+    const base = branchEntries(2, SOURCE, 1)
+    await h.write(SOURCE, base)
+    await h.record('T', SOURCE, rehomeRecord({ title: 'Parent' }))
+    await h.write(richer, [...fork(base, SOURCE, richer, 'Richer copy'), entry('user', 3, null, richer)])
+    await h.record('P', richer, rehomeRecord({ title: 'Richer copy' }))
+    if (location !== 'without history') await h.write(child, fork(base, SOURCE, child, 'Fork'))
+    await h.record(location === 'source' ? 'P' : 'T', child, rehomeRecord({ title: 'Fork', isArchived, forkedFromSessionId: `local_${SOURCE}` }))
+    const all = await accounts(h.paths), from = all.find(row => row.account === h.acct.P), to = all.find(row => row.account === h.acct.T)
+    const originals = await Promise.all([...from.sessions, ...to.sessions].map(async row => [row.file, await readFile(row.file)]))
+    const inv = await inventory([from], to, h.paths)
+    assert.deepEqual(inv.move.map(row => row.id), location === 'source' ? [richer, child] : [richer])
+    const moved = await move(inv, to, h.paths)
+    assert.equal(moved.ok, true)
+    assert.equal(moved.receipt.superseded.some(row => !row.source), false)
+    assert.deepEqual(await readdir(h.dir('P')), [])
+    assert.deepEqual((await readdir(h.dir('T'))).sort(), [SOURCE, richer, child].map(sid => `local_${sid}.json`).sort())
+    const placed = JSON.parse(await readFile(path.join(h.dir('T'), `local_${child}.json`)))
+    assert.equal(placed.forkedFromSessionId, `local_${SOURCE}`)
+    assert.equal(placed.isArchived, isArchived)
+    assert.ok((await undo(h.paths)).dest)
+    assert.deepEqual((await readdir(h.dir('T'))).sort(), to.sessions.map(row => path.basename(row.file)).sort())
+    for (const [file, bytes] of originals) assert.deepEqual(await readFile(file), bytes)
+  }
+})
+
+test('identical Desktop parent and fork histories are reported as overlapping versions', async () => {
+  const h = await home(), child = id(777), base = branchEntries(2, SOURCE, 1)
+  await h.write(SOURCE, base)
+  await h.write(child, fork(base, SOURCE, child, 'Fork'))
+  await h.record('P', SOURCE, rehomeRecord())
+  await h.record('P', child, rehomeRecord({ forkedFromSessionId: `local_${SOURCE}` }))
+  const result = await cli(h.root, ['--from', 'p@example.com personal', '--to', 'z@example.com personal', '--dry-run'])
+  assert.equal(result.code, 0)
+  assert.match(result.stdout, /2 overlapping versions, kept separate/)
+  assert.doesNotMatch(result.stdout, /grew apart/)
 })
 
 test('progress begins before analysis and every counted phase reaches its total', async () => {

--- a/transplant.test.js
+++ b/transplant.test.js
@@ -3,7 +3,8 @@ import { execFile, spawn, spawnSync } from 'node:child_process'
 import { createHash, randomUUID } from 'node:crypto'
 import { once } from 'node:events'
 import { appendFileSync, readFileSync, readdirSync, writeFileSync } from 'node:fs'
-import { appendFile, mkdir, mkdtemp, open, readdir, readFile, rename, stat, symlink, unlink, writeFile } from 'node:fs/promises'
+import fs, { appendFile, mkdir, mkdtemp, open, readdir, readFile, rename, stat, symlink, unlink, writeFile } from 'node:fs/promises'
+import { syncBuiltinESMExports } from 'node:module'
 import os from 'node:os'
 import path from 'node:path'
 import test from 'node:test'
@@ -3774,6 +3775,119 @@ test('Undo rechecks destination forks after cloud restoration before removing an
   assert.ok((await undo(h.paths, { cloud })).dest)
   assert.ok(await readFile(path.join(h.dir('P'), `local_${SOURCE}.json`)))
   assert.deepEqual(await readdir(h.dir('T')), [])
+})
+
+test('Undo restores destination parents when forks arrive during local mutations and remains recoverable', async () => {
+  for (const stage of ['restore source', 'park destination']) for (const unreadable of [false, true]) {
+    const h = await home(), child = id(777), later = id(778), base = branchEntries(2, SOURCE, 1)
+    await h.write(SOURCE, base)
+    await h.record('P', SOURCE, rehomeRecord())
+    await h.write(child, fork(base, SOURCE, child, 'Moved fork'))
+    await h.record('P', child, rehomeRecord({ forkedFromSessionId: `local_${SOURCE}` }))
+    const all = await accounts(h.paths), from = all.find(row => row.account === h.acct.P), to = all.find(row => row.account === h.acct.T)
+    const originals = await Promise.all(from.sessions.map(async row => [row.file, await readFile(row.file)]))
+    const moved = await move(await inventory([from], to, h.paths), to, h.paths)
+    assert.equal(moved.ok, true)
+    const destination = await Promise.all(moved.receipt.sessions.map(async row => [row.record, await readFile(row.record)]))
+    const sourceParent = path.join(h.dir('P'), `local_${SOURCE}.json`), targetParent = path.join(h.dir('T'), `local_${SOURCE}.json`)
+    const originalRename = fs.rename
+    let injected = false, refused
+    try {
+      fs.rename = async (source, target) => {
+        await originalRename(source, target)
+        if (injected || !(stage === 'restore source' ? target === sourceParent : source === targetParent)) return
+        injected = true
+        if (unreadable) await writeFile(path.join(h.dir('T'), `local_${later}.json`), '{broken')
+        else await h.record('T', later, rehomeRecord({ isArchived: true, forkedFromSessionId: `local_${SOURCE}` }))
+      }
+      syncBuiltinESMExports()
+      refused = await undo(h.paths)
+    } finally {
+      fs.rename = originalRename
+      syncBuiltinESMExports()
+    }
+    assert.equal(injected, true)
+    assert.equal(refused.dest, undefined)
+    assert.match(refused.restoreProblems[0], unreadable ? /unreadable Desktop record:/ : /parent Desktop record would be removed by Undo/)
+    for (const [file, bytes] of destination) assert.deepEqual(await readFile(file), bytes)
+    if (!unreadable) assert.equal(JSON.parse(await readFile(path.join(h.dir('T'), `local_${later}.json`))).forkedFromSessionId, `local_${SOURCE}`)
+    for (const [file, bytes] of originals) assert.deepEqual(await readFile(file), bytes)
+    const receipt = JSON.parse(await readFile(moved.file))
+    assert.equal(receipt.undoing.length, 2)
+    assert.deepEqual(receipt.superseded, moved.receipt.superseded)
+    for (const row of receipt.superseded) for (const [, parked] of row.moved) assert.equal(await readFile(parked).catch(() => null), null)
+    const retried = await finishPending(h.paths)
+    assert.equal(retried.ok, false)
+    assert.match(retried.reconciled.problems[0], unreadable ? /unreadable Desktop record:/ : /parent Desktop record would be removed by Undo/)
+    for (const [file, bytes] of destination) assert.deepEqual(await readFile(file), bytes)
+    await unlink(path.join(h.dir('T'), `local_${later}.json`))
+    const undone = await finishWorkflow(h.paths)
+    assert.ok(undone.dest)
+    assert.equal(undone.complete, true)
+    assert.equal(JSON.parse(await readFile(path.join(undone.dest, 'receipt.json'))).at, moved.receipt.at)
+    for (const [file, bytes] of originals) assert.deepEqual(await readFile(file), bytes)
+    assert.deepEqual(await readdir(h.dir('T')), [])
+  }
+})
+
+test('Undo rollback preserves foreign records and source forks while restoring every safe destination record', async () => {
+  for (const change of ['source record', 'destination parent', 'destination sibling', 'source fork']) {
+    const h = await home(), child = id(777), later = id(778), sourceFork = id(779), base = branchEntries(2, SOURCE, 1)
+    await h.write(SOURCE, base)
+    await h.record('P', SOURCE, rehomeRecord())
+    await h.write(child, fork(base, SOURCE, child, 'Moved fork'))
+    await h.record('P', child, rehomeRecord({ forkedFromSessionId: `local_${SOURCE}` }))
+    const all = await accounts(h.paths), from = all.find(row => row.account === h.acct.P), to = all.find(row => row.account === h.acct.T)
+    const originals = new Map(await Promise.all(from.sessions.map(async row => [row.file, await readFile(row.file)])))
+    const moved = await move(await inventory([from], to, h.paths), to, h.paths)
+    assert.equal(moved.ok, true)
+    const destination = new Map(await Promise.all(moved.receipt.sessions.map(async row => [row.record, await readFile(row.record)])))
+    const sourceParent = path.join(h.dir('P'), `local_${SOURCE}.json`), targetParent = path.join(h.dir('T'), `local_${SOURCE}.json`)
+    const targetChild = path.join(h.dir('T'), `local_${child}.json`), parkedParent = path.join(h.paths.state, 'quarantine', moved.receipt.at, path.basename(targetParent))
+    const foreignFile = change === 'source record' ? sourceParent : change === 'destination parent' ? targetParent : change === 'destination sibling' ? targetChild : path.join(h.dir('P'), `local_${sourceFork}.json`)
+    const originalRename = fs.rename
+    let injected = false, refused, foreignBytes
+    try {
+      fs.rename = async (source, target) => {
+        await originalRename(source, target)
+        if (injected || source !== targetParent || target !== parkedParent) return
+        injected = true
+        await h.record('T', later, rehomeRecord({ forkedFromSessionId: `local_${SOURCE}` }))
+        if (change === 'source fork') await h.record('P', sourceFork, rehomeRecord({ forkedFromSessionId: `local_${SOURCE}` }))
+        else await h.record(change === 'source record' ? 'P' : 'T', change === 'destination sibling' ? child : SOURCE,
+          rehomeRecord({ title: 'Independent change', ...(change === 'destination sibling' ? { forkedFromSessionId: `local_${SOURCE}` } : {}) }))
+        foreignBytes = await readFile(foreignFile)
+      }
+      syncBuiltinESMExports()
+      refused = await undo(h.paths)
+    } finally {
+      fs.rename = originalRename
+      syncBuiltinESMExports()
+    }
+    assert.equal(injected, true)
+    assert.equal(refused.dest, undefined)
+    assert.match(refused.restoreProblems[0], /parent Desktop record would be removed by Undo/)
+    if (change !== 'source fork') assert.ok(refused.restoreProblems.some(problem => /restore path occupied|recovery artifact changed/.test(problem)))
+    assert.deepEqual(await readFile(foreignFile), foreignBytes)
+    for (const [file, bytes] of originals) assert.deepEqual(await readFile(file), file === foreignFile ? foreignBytes : bytes)
+    for (const [file, bytes] of destination) assert.deepEqual(await readFile(file), file === foreignFile ? foreignBytes : bytes)
+    if (change === 'destination parent') assert.deepEqual(await readFile(parkedParent), destination.get(targetParent))
+    const receipt = JSON.parse(await readFile(moved.file))
+    assert.equal(receipt.undoing.length, 2)
+    assert.deepEqual(receipt.superseded, moved.receipt.superseded)
+    if (change !== 'source fork') {
+      await rename(foreignFile, `${foreignFile}.foreign`)
+      if (change === 'source record') await writeFile(foreignFile, originals.get(foreignFile))
+      if (change === 'destination sibling') await writeFile(foreignFile, destination.get(foreignFile))
+    }
+    await unlink(path.join(h.dir('T'), `local_${later}.json`))
+    const undone = await finishWorkflow(h.paths)
+    assert.ok(undone.dest)
+    assert.equal(undone.complete, true)
+    for (const [file, bytes] of originals) assert.deepEqual(await readFile(file), bytes)
+    for (const file of destination.keys()) assert.equal(await readFile(file).catch(() => null), null)
+    assert.deepEqual(await readFile(change === 'source fork' ? foreignFile : `${foreignFile}.foreign`), foreignBytes)
+  }
 })
 
 test('destination parents survive forks added after inventory or during final preparation', async () => {


### PR DESCRIPTION
Desktop parent and fork records with compatible histories could be grouped together and refused, or treated as already present because another record covered their history. Explicit Desktop forks now keep separate records, including archived forks, and their required parents keep the exact Desktop IDs the forks reference.

Retirement preserves parent links in both source and destination folders, including references added after inventory. Held forks and their required parents finish together. Undo refuses if a newly created fork needs a record it would remove. If a dependency appears during Undo, safe destination records are restored and the receipt remains recoverable. Late changes use the existing rollback journal. Remote Control uses a unique verified bridge link to distinguish matching histories, while ambiguous matches still refuse. Version is 4.0.4.

Validation:

- All 189 tests and Swift typecheck passed
- Parent/fork moves, partial selection, worker and task holds, archive state, missing histories, transitive parent links, late-reference rollback, and Undo
- Remote Control bridge matching, ambiguous-match refusal, activation, archival, and Undo
- Actual menubar move verified both records arrived with unchanged transcript bytes and inodes, followed by the owner confirming them after restarting Desktop
- A 1000-session fixture with small synthetic histories moved and verified in 2.7 seconds
