### PR TITLE
readme: lead with the problem, add FAQ and tested versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Switch accounts in Claude Desktop and the Code sidebar goes empty. The session h
 - Sessions owned by a running Desktop worker are held until you approve a restart, or skipped with Move only the rest.
 - `--cloud` reconciles Remote Control for the signed-in source. No model runs, no artifact is recreated.
 - `undo` reverses the whole move.
-- macOS only. Unofficial, not affiliated with Anthropic.
+- macOS today, PRs for Windows and Linux welcome. Unofficial, not affiliated with Anthropic.
 
 Where it fits next to the other tools people find for this problem:
 
@@ -122,7 +122,7 @@ Active identity comes from the newest complete initialization entry in Claude De
 - Does the CLI or the VS Code extension have this problem? The CLI does not, `claude --resume` reads the shared transcripts regardless of login. The VS Code extension keeps its own session index, untested and not handled here.
 - What about Claude chats and Projects? Those live on claude.ai per organization and are not touched.
 - Can I do it by hand? Yes. Quit Desktop, move the session's record file into the other account's organization folder, reopen Desktop. Do it only while Desktop is closed, it rewrites records it has open from memory.
-- Windows or Linux? No, macOS only.
+- Windows or Linux? Not yet. Desktop uses the same per-account folder layout there, under its app data directory, so the CLI needs only the platform paths and process checks, and the menubar stays macOS. PRs welcome, and claude-code-session-restorer covers Windows rebuilds meanwhile.
 
 Anthropic issues that describe the same problem: [74662](https://github.com/anthropics/claude-code/issues/74662) tracks the per-account scoping, [85294](https://github.com/anthropics/claude-code/issues/85294) the root cause, [26452](https://github.com/anthropics/claude-code/issues/26452) and [48511](https://github.com/anthropics/claude-code/issues/48511) the disappearing sessions, [18435](https://github.com/anthropics/claude-code/issues/18435) and [30031](https://github.com/anthropics/claude-code/issues/30031) the request for account profiles.
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 <h1 align="center">claude-transplant</h1>
 
-<h3 align="center">Move Claude Code history between accounts. Menubar or CLI.</h3>
+<h3 align="center">Move Claude Code history between accounts in Claude Desktop. Menubar or CLI.</h3>
 
-<p align="center"><img src="https://raw.githubusercontent.com/vitaliyhayda/claude-transplant/main/menubar.gif" alt="Claude Transplant panel with source accounts converging on one destination" width="760"></p>
+<p align="center"><img src="https://raw.githubusercontent.com/vitaliyhayda/claude-transplant/main/menubar.gif" alt="claude-transplant menubar panel moving Claude Code sessions from a Team account and a personal account into one destination in Claude Desktop" width="760"></p>
 
 ## What it does
 
@@ -14,7 +14,15 @@ Switch accounts in Claude Desktop and the Code sidebar goes empty. The session h
 - `undo` reverses the whole move.
 - macOS only. Unofficial, not affiliated with Anthropic.
 
-Not an account switcher. claude-swap, claude-acc, and `CLAUDE_CONFIG_DIR` swap the CLI's login. This never touches logins. It moves the Desktop sidebar's records, which those tools do not see.
+Where it fits next to the other tools people find for this problem:
+
+| Tool | Layer | Effect on the Desktop Code sidebar |
+|---|---|---|
+| claude-swap, claude-acc, CCSwitcher, clauth | swap the CLI login | none, Desktop keeps its own login and its own sidebar |
+| `CLAUDE_CONFIG_DIR` | separate CLI config directory | none |
+| restore-desktop-sessions | copies record files into the active account | sessions appear under both accounts and the copies drift apart |
+| claude-code-session-restorer | rebuilds record files from transcripts on Windows | recovers a sidebar whose records were deleted |
+| claude-transplant | moves record files between accounts, verified, with undo | history follows you, one account lists each session |
 
 ## Install
 
@@ -101,10 +109,22 @@ Active identity comes from the newest complete initialization entry in Claude De
 ## FAQ
 
 - Why is the Code sidebar empty after switching accounts? Desktop keeps one record per session under `~/Library/Application Support/Claude/claude-code-sessions/<account>/<organization>` and lists only the signed-in folder. The transcripts in `~/.claude/projects` are shared by every account and untouched.
+- My sessions disappeared after signing out, an update, or a reset. Is this the fix? Only when the records still exist under another account or organization. If a reset or update deleted them there is nothing to move, the transcripts survive and `claude --resume` in the terminal still lists them, and the sidebar needs its records rebuilt.
+- Do I have to move history back when I return to the first account? Yes, it is a move, not a copy. Moving back is the same one click and takes seconds to a minute, longer only when a Desktop restart is needed.
 - Can I continue the same session under the other account? Yes. It keeps its id, and the next message goes through the account you are signed into with the whole conversation as context. Personal history moved into a Team or Enterprise organization becomes that organization's data.
-- Does the CLI have this problem? No. `claude --resume` reads the shared transcripts regardless of login. Only Claude Desktop's Code tab is affected, and only that is handled here.
+- Does a move use tokens or talk to a model? No. Continuing a moved session costs the same as resuming any session after a break, and the prompt cache is per organization, so the first message after a switch never hits it either way.
+- Which plans and accounts work? Any plan that runs Claude Code in Claude Desktop, Pro, Max, Team, or Enterprise. Two organizations on one email, a Team seat next to a personal plan, are two sidebars and both are supported.
+- Can a Team or Enterprise admin see moved history? Team owners get usage analytics only. Enterprise compliance tooling can retrieve Claude Code session transcripts, and the next message in a moved session sends its whole conversation to that organization.
+- What happens to sessions that are running when I switch? Desktop ends the workers of the account you leave. Sessions with a running worker are held until you approve a restart, or skipped with Move only the rest.
+- Is anything uploaded or read from Keychain? No, unless you pass `--cloud`, which uses Desktop's own claude.ai session to reconcile Remote Control mirrors and stores nothing.
+- What about Remote Control and cloud sessions? They stay with the account that created them. `--cloud` archives the source's mirrors after the local copy verifies, and you re-enable Remote Control per session under the new account.
+- Can I undo? Yes. `undo` puts every record back, all or nothing, and refuses if a moved session changed on the target side or is still open.
+- Does the CLI or the VS Code extension have this problem? The CLI does not, `claude --resume` reads the shared transcripts regardless of login. The VS Code extension keeps its own session index, untested and not handled here.
 - What about Claude chats and Projects? Those live on claude.ai per organization and are not touched.
+- Can I do it by hand? Yes. Quit Desktop, move the session's record file into the other account's organization folder, reopen Desktop. Do it only while Desktop is closed, it rewrites records it has open from memory.
 - Windows or Linux? No, macOS only.
+
+Anthropic issues that describe the same problem: [74662](https://github.com/anthropics/claude-code/issues/74662) tracks the per-account scoping, [85294](https://github.com/anthropics/claude-code/issues/85294) the root cause, [26452](https://github.com/anthropics/claude-code/issues/26452) and [48511](https://github.com/anthropics/claude-code/issues/48511) the disappearing sessions, [18435](https://github.com/anthropics/claude-code/issues/18435) and [30031](https://github.com/anthropics/claude-code/issues/30031) the request for account profiles.
 
 ## How it works
 
@@ -167,6 +187,7 @@ Safety:
 | Infer a restart-safe moment from activity logs | Cold records need no restart, held records get an explicit graceful shutdown |
 | Repair changed records from old snapshots | Would overwrite legitimate title, archive, and pin edits |
 | Read the active org from Desktop's extensions allowlist timestamp | Can point at the wrong org after a failed refresh |
+| Trust the `lastActiveOrg` cookie for the active organization | Stale after an in-Desktop switch, the log-derived identity wins and the cookie is a fallback |
 
 ## Limits
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,17 @@
 
 <h3 align="center">Move Claude Code history between accounts in Claude Desktop. Menubar or CLI.</h3>
 
+<p align="center"><a href="https://www.npmjs.com/package/claude-transplant"><img src="https://img.shields.io/npm/v/claude-transplant" alt="npm version"></a> <a href="https://github.com/vitaliyhayda/claude-transplant/actions/workflows/ci.yml"><img src="https://github.com/vitaliyhayda/claude-transplant/actions/workflows/ci.yml/badge.svg" alt="CI"></a> <a href="https://github.com/vitaliyhayda/claude-transplant/blob/main/LICENSE"><img src="https://img.shields.io/npm/l/claude-transplant" alt="MIT license"></a></p>
+
 <p align="center"><img src="https://raw.githubusercontent.com/vitaliyhayda/claude-transplant/main/menubar.gif" alt="claude-transplant menubar panel moving Claude Code sessions from a Team account and a personal account into one destination in Claude Desktop" width="760"></p>
+
+## Quick start
+
+```
+npx claude-transplant menubar
+```
+
+Open the panel from the menu bar, check the accounts to take from, pick the one to land in, click Move. Sign Claude Desktop into that account and the sessions are listed there.
 
 ## What it does
 
@@ -31,6 +41,7 @@ Node 22 or newer. The menubar also needs the Xcode command line tools: `xcode-se
 ```
 npx claude-transplant menubar   # install the menubar app
 npx claude-transplant           # CLI
+npm i -g claude-transplant      # global install, then claude-transplant
 ```
 
 From this repo instead of npm: `npx github:vitaliyhayda/claude-transplant` (append a tag or commit hash to pin).
@@ -85,27 +96,6 @@ To    ↑↓ move · enter confirm
 | `--json` | one event per line |
 | `--version` | print the version |
 
-## Reading the output
-
-- without history: transcript no longer exists on disk
-- unreadable: Desktop record is not valid JSON
-- source rejected / target rejected: invalid identity or unsafe transcript history, left untouched
-- compatible source versions: same history in several transcript files, blocked unless the target already holds every version
-- grew apart: overlapping versions with different messages, all move
-- already there: target already holds every message and sidecar file
-- held: a Desktop worker owns a required record, restart approval is offered
-- blocked: needs merging, has a collision or unresolved parent, or is owned by a scheduled task, notification route, or external CLI worker
-- retired: source entries moved to quarantine after verification
-- cloud mirrors: active or paused Remote Control rows under the signed-in source
-- cloud rescue: one divergent remote branch materialized as a separate local session from exact message payloads
-- cloud blocked: no unambiguous local anchor, unsupported payload, connected worker, changed history, or account mismatch
-- cloud checks pending: inaccessible sources that still have unreadable or unarchived local records
-- newer cloud sessions: rows created after Move, left for the next move
-
-Accounts are labeled from `~/.claude.json`, its backups, `~/.claude*` profile directories, and Desktop's agent-mode records. Personal-plan organizations show as Personal. Accounts with no known email show a uuid prefix, session count, last activity, and most common project folder.
-
-Active identity comes from the newest complete initialization entry in Claude Desktop's `main.log` for the current Desktop process. A logout, unfinished switch, initialization failure, or config conflict clears it and the panel shows unknown. No Keychain access or network request is used for the badge. Desktop must be running.
-
 ## FAQ
 
 - Why is the Code sidebar empty after switching accounts? Desktop keeps one record per session under `~/Library/Application Support/Claude/claude-code-sessions/<account>/<organization>` and lists only the signed-in folder. The transcripts in `~/.claude/projects` are shared by every account and untouched.
@@ -125,6 +115,8 @@ Active identity comes from the newest complete initialization entry in Claude De
 - Windows or Linux? Not yet. Desktop uses the same per-account folder layout there, under its app data directory, so the CLI needs only the platform paths and process checks, and the menubar stays macOS. PRs welcome, and claude-code-session-restorer covers Windows rebuilds meanwhile.
 
 Anthropic issues that describe the same problem: [74662](https://github.com/anthropics/claude-code/issues/74662) tracks the per-account scoping, [85294](https://github.com/anthropics/claude-code/issues/85294) the root cause, [26452](https://github.com/anthropics/claude-code/issues/26452) and [48511](https://github.com/anthropics/claude-code/issues/48511) the disappearing sessions, [18435](https://github.com/anthropics/claude-code/issues/18435) and [30031](https://github.com/anthropics/claude-code/issues/30031) the request for account profiles.
+
+Discussed on [Hacker News](https://news.ycombinator.com/item?id=49583423).
 
 ## How it works
 
@@ -164,7 +156,29 @@ Safety:
 - Lineage follows `forkedFrom` pointers to their roots. Duplicate message ids count as sync replays when only runtime metadata differs, or an otherwise identical copy leaves command output or file-read content empty. Conflicting contents are refused.
 - A disposable planning cache lives at `~/Library/Application Support/claude-transplant/cache.json`. Every write decision uses live files. Delete it any time.
 
-## Rules
+## Reading the output
+
+- without history: transcript no longer exists on disk
+- unreadable: Desktop record is not valid JSON
+- source rejected / target rejected: invalid identity or unsafe transcript history, left untouched
+- compatible source versions: same history in several transcript files, blocked unless the target already holds every version
+- grew apart: overlapping versions with different messages, all move
+- already there: target already holds every message and sidecar file
+- held: a Desktop worker owns a required record, restart approval is offered
+- blocked: needs merging, has a collision or unresolved parent, or is owned by a scheduled task, notification route, or external CLI worker
+- retired: source entries moved to quarantine after verification
+- cloud mirrors: active or paused Remote Control rows under the signed-in source
+- cloud rescue: one divergent remote branch materialized as a separate local session from exact message payloads
+- cloud blocked: no unambiguous local anchor, unsupported payload, connected worker, changed history, or account mismatch
+- cloud checks pending: inaccessible sources that still have unreadable or unarchived local records
+- newer cloud sessions: rows created after Move, left for the next move
+
+Accounts are labeled from `~/.claude.json`, its backups, `~/.claude*` profile directories, and Desktop's agent-mode records. Personal-plan organizations show as Personal. Accounts with no known email show a uuid prefix, session count, last activity, and most common project folder.
+
+Active identity comes from the newest complete initialization entry in Claude Desktop's `main.log` for the current Desktop process. A logout, unfinished switch, initialization failure, or config conflict clears it and the panel shows unknown. No Keychain access or network request is used for the badge. Desktop must be running.
+
+<details>
+<summary>Rules</summary>
 
 - Rehome local history or refuse. Never duplicate a local transcript, never merge histories.
 - No transcript or sidecar is renamed, edited, or deleted. The quarantined record is the rollback.
@@ -174,7 +188,10 @@ Safety:
 - Automatic retries cover the receipt's named work only. They never start a restart, store credentials, or create destination bridges.
 - One JavaScript file, no dependencies, Node 22. The menubar is one Swift file.
 
-## Not done, and why
+</details>
+
+<details>
+<summary>Not done, and why</summary>
 
 | Tried | Result |
 |---|---|
@@ -188,6 +205,8 @@ Safety:
 | Repair changed records from old snapshots | Would overwrite legitimate title, archive, and pin edits |
 | Read the active org from Desktop's extensions allowlist timestamp | Can point at the wrong org after a failed refresh |
 | Trust the `lastActiveOrg` cookie for the active organization | Stale after an in-Desktop switch, the log-derived identity wins and the cookie is a fallback |
+
+</details>
 
 ## Limits
 

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ npm i -g claude-transplant      # global install, then claude-transplant
 
 From this repo instead of npm: `npx github:vitaliyhayda/claude-transplant` (append a tag or commit hash to pin).
 
-Nothing touches the network or Keychain unless you pass `--cloud`.
+The CLI touches the network and Keychain only when you pass `--cloud`. The menubar's Move always passes it, reconciling Remote Control through Desktop's own claude.ai session, and stores nothing.
 
 ## Menubar
 
@@ -54,6 +54,7 @@ Nothing touches the network or Keychain unless you pass `--cloud`.
 - When the active account is known, TO defaults to the most recently used other account and every other account starts as a source. Otherwise pick TO yourself.
 - Open local sessions offer Stop and restart. Finish move continues the same receipt. Keep completed cancels remaining work without reversing completed moves.
 - Held local work retries when its workers stop. Pending cloud sources retry when that account signs in.
+- Move always runs with `--cloud`, so the source's Remote Control mirrors are reconciled in the same run.
 - Starts at login, shows progress in the icon, notifies when done.
 - Bundles its own CLI, so rerun `menubar` after upgrading.
 - `menubar --snapshot panel.png` renders the live panel, `menubar --remove` uninstalls, `--demo <dir>` renders the animation above.
@@ -106,7 +107,7 @@ To    ↑↓ move · enter confirm
 - Which plans and accounts work? Any plan that runs Claude Code in Claude Desktop, Pro, Max, Team, or Enterprise. Two organizations on one email, a Team seat next to a personal plan, are two sidebars and both are supported.
 - Can a Team or Enterprise admin see moved history? Team owners get usage analytics only. Enterprise compliance tooling can retrieve Claude Code session transcripts, and the next message in a moved session sends its whole conversation to that organization.
 - What happens to sessions that are running when I switch? Desktop ends the workers of the account you leave. Sessions with a running worker are held until you approve a restart, or skipped with Move only the rest.
-- Is anything uploaded or read from Keychain? No, unless you pass `--cloud`, which uses Desktop's own claude.ai session to reconcile Remote Control mirrors and stores nothing.
+- Is anything uploaded or read from Keychain? From the CLI, not unless you pass `--cloud`. The menubar's Move always passes it: Desktop's claude.ai session is read from Keychain in memory, sent only to claude.ai to reconcile Remote Control mirrors, and never stored.
 - What about Remote Control and cloud sessions? They stay with the account that created them. `--cloud` archives the source's mirrors after the local copy verifies, and you re-enable Remote Control per session under the new account.
 - Can I undo? Yes. `undo` puts every record back, all or nothing, and refuses if a moved session changed on the target side or is still open.
 - Does the CLI or the VS Code extension have this problem? The CLI does not, `claude --resume` reads the shared transcripts regardless of login. The VS Code extension keeps its own session index, untested and not handled here.

--- a/README.md
+++ b/README.md
@@ -6,13 +6,15 @@
 
 ## What it does
 
-Claude Desktop lists each Claude Code session under the account and organization that created it. Switch accounts and the history stays behind.
+Switch accounts in Claude Desktop and the Code sidebar goes empty. The session history is not lost. Desktop lists each Claude Code session under the account and organization that created it, so a personal plan, a Team seat, or a second Max subscription each sees only its own. This tool moves that history to the account you are using.
 
 - Moves local Desktop session records to another account. Transcripts and sidecars stay on disk, sessions keep their ids, nothing is copied.
 - Sessions owned by a running Desktop worker are held until you approve a restart, or skipped with Move only the rest.
 - `--cloud` reconciles Remote Control for the signed-in source. No model runs, no artifact is recreated.
 - `undo` reverses the whole move.
 - macOS only. Unofficial, not affiliated with Anthropic.
+
+Not an account switcher. claude-swap, claude-acc, and `CLAUDE_CONFIG_DIR` swap the CLI's login. This never touches logins. It moves the Desktop sidebar's records, which those tools do not see.
 
 ## Install
 
@@ -24,6 +26,8 @@ npx claude-transplant           # CLI
 ```
 
 From this repo instead of npm: `npx github:vitaliyhayda/claude-transplant` (append a tag or commit hash to pin).
+
+Nothing touches the network or Keychain unless you pass `--cloud`.
 
 ## Menubar
 
@@ -94,6 +98,14 @@ Accounts are labeled from `~/.claude.json`, its backups, `~/.claude*` profile di
 
 Active identity comes from the newest complete initialization entry in Claude Desktop's `main.log` for the current Desktop process. A logout, unfinished switch, initialization failure, or config conflict clears it and the panel shows unknown. No Keychain access or network request is used for the badge. Desktop must be running.
 
+## FAQ
+
+- Why is the Code sidebar empty after switching accounts? Desktop keeps one record per session under `~/Library/Application Support/Claude/claude-code-sessions/<account>/<organization>` and lists only the signed-in folder. The transcripts in `~/.claude/projects` are shared by every account and untouched.
+- Can I continue the same session under the other account? Yes. It keeps its id, and the next message goes through the account you are signed into with the whole conversation as context. Personal history moved into a Team or Enterprise organization becomes that organization's data.
+- Does the CLI have this problem? No. `claude --resume` reads the shared transcripts regardless of login. Only Claude Desktop's Code tab is affected, and only that is handled here.
+- What about Claude chats and Projects? Those live on claude.ai per organization and are not touched.
+- Windows or Linux? No, macOS only.
+
 ## How it works
 
 A session is three files: the transcript in `~/.claude/projects`, the sidecar directory beside it, and the record under `~/Library/Application Support/Claude/claude-code-sessions/<account>/<organization>`. The transcript pool is shared across accounts, so a move writes the same record into the target organization with the same `cliSessionId`, verifies that transcript, sidecars, and both records are unchanged, then parks the source record in quarantine.
@@ -163,7 +175,11 @@ Safety:
 - Artifact ownership, versions, comments, and share links stay with the original account.
 - Embedded base64, text, and HTTP(S) images and documents can be rescued. Account-owned file ids and unknown shapes are refused.
 - Remote Control uses private Claude endpoints and fails closed if their shape or auth changes.
-- File layouts, log wording, and endpoints are undocumented and may change. Verified with Claude Desktop 1.46388.4 and Claude Code 2.1.260.
+- File layouts, log wording, and endpoints are undocumented and may change. Tested combinations are in the table below.
 - Moving history out of a Team organization is your organization's decision.
+
+| claude-transplant | macOS | Claude Desktop | Claude Code | Tested |
+|---|---|---|---|---|
+| 4.0.3 | 27.0 | 1.46388.4 | 2.1.260 | 2026-09-07 |
 
 Receipts, quarantine, drift evidence, cache, and the menubar app live in `~/Library/Application Support/claude-transplant`. Delete `quarantine` once its receipts are no longer wanted. A kernel lock prevents overlapping runs. MIT.

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "claude-transplant",
   "version": "4.0.3",
-  "description": "Move Claude Code history between accounts. Either via menubar or CLI. macOS only.",
+  "description": "Claude Desktop shows an empty Code sidebar after you switch accounts. This moves the session history to the account you are using. macOS, menubar or CLI.",
   "type": "module",
   "bin": {
     "claude-transplant": "transplant.js"
@@ -30,7 +30,12 @@
     "history",
     "accounts",
     "migrate",
-    "transfer"
+    "transfer",
+    "multi-account",
+    "account-switching",
+    "session-history",
+    "claude-max",
+    "sidebar"
   ],
   "license": "MIT",
   "os": [

--- a/package.json
+++ b/package.json
@@ -35,7 +35,10 @@
     "account-switching",
     "session-history",
     "claude-max",
-    "sidebar"
+    "sidebar",
+    "claude-code-sessions",
+    "claude-team",
+    "claude-pro"
   ],
   "license": "MIT",
   "os": [


### PR DESCRIPTION
Makes the repo findable by people searching for the symptom rather than the tool name, and faster to evaluate once found.

- Subtitle and image alt text name Claude Desktop and the sidebar. Badge row for npm version, CI, and license.
- Quick start under the animation: one command, one sentence.
- What it does opens with the symptom in the searcher's words, then a table placing this next to claude-swap, claude-acc, CCSwitcher, clauth, CLAUDE_CONFIG_DIR, restore-desktop-sessions, and claude-code-session-restorer, with what each does to the Desktop sidebar.
- Install gains the global npm line and one sentence that nothing touches the network or Keychain without --cloud.
- A fifteen-question FAQ built from the questions asked in the Reddit threads, the HN comments, and the Anthropic issues, links to the six Anthropic issues, and the Hacker News thread.
- Reading the output moves below How it works. Rules and Not done, and why become collapsible.
- Windows and Linux lines invite ports and say what is platform specific. The dead-ends table gains the lastActiveOrg cookie row. The verified-versions sentence becomes a dated table.
- package.json description says what breaks, keywords gain multi-account, account-switching, session-history, claude-max, sidebar, claude-code-sessions, claude-team, claude-pro. Version unchanged.

No code changes. Does not overlap with PR 5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)