### PR TITLE
readme: question headings, GitHub Pages site, author

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,53 @@
+name: pages
+on:
+  push:
+    branches: [main]
+    paths: [README.md, package.json, .github/workflows/pages.yml]
+  workflow_dispatch:
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+concurrency:
+  group: pages
+  cancel-in-progress: true
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - run: pip install markdown==3.7
+      - run: |
+          python3 - <<'PY'
+          import json, markdown, pathlib
+          pkg = json.load(open('package.json'))
+          src = pathlib.Path('README.md').read_text(encoding='utf-8').replace('<details>', '<details markdown="1">')
+          body = markdown.markdown(src, extensions=['tables', 'fenced_code', 'toc', 'md_in_html'])
+          url = pkg['homepage']
+          title = 'claude-transplant: move Claude Code history between accounts in Claude Desktop'
+          desc = pkg['description']
+          head = f'''<!doctype html><html lang="en"><head><meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1">
+          <title>{title}</title><meta name="description" content="{desc}"><link rel="canonical" href="{url}">
+          <meta property="og:title" content="{title}"><meta property="og:description" content="{desc}"><meta property="og:url" content="{url}">
+          <meta property="og:image" content="https://raw.githubusercontent.com/vitaliyhayda/claude-transplant/main/menubar.gif"><meta name="twitter:card" content="summary_large_image">
+          <style>:root{{color-scheme:light dark}}body{{margin:0 auto;max-width:800px;padding:24px 16px;font:16px/1.55 -apple-system,system-ui,sans-serif}}pre,code{{font:14px/1.45 ui-monospace,Menlo,monospace}}pre{{overflow:auto;padding:12px;background:rgba(127,127,127,.12);border-radius:8px}}table{{border-collapse:collapse;display:block;overflow:auto}}td,th{{border:1px solid rgba(127,127,127,.35);padding:6px 10px;text-align:left}}img{{max-width:100%}}a{{color:#2563eb}}details{{margin:12px 0}}</style></head><body><main>'''
+          tail = f'</main><footer><p><a href="{pkg["repository"]["url"].replace("git+", "").replace(".git", "")}">Source on GitHub</a> · <a href="https://www.npmjs.com/package/{pkg["name"]}">npm</a></p></footer></body></html>'
+          out = pathlib.Path('site'); out.mkdir(exist_ok=True)
+          (out / 'index.html').write_text(head + body + tail, encoding='utf-8')
+          (out / '.nojekyll').write_text('')
+          PY
+      - uses: actions/upload-pages-artifact@v3
+        with:
+          path: site
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - id: deployment
+        uses: actions/deploy-pages@v4

--- a/README.md
+++ b/README.md
@@ -116,13 +116,34 @@ Command and flag names are stable. Renames get a deprecation release first.
 
 ## FAQ
 
-- Why is the Code sidebar empty after switching accounts? Desktop keeps one record per session under `~/Library/Application Support/Claude/claude-code-sessions/<account>/<organization>` and lists only the signed-in folder. The transcripts in `~/.claude/projects` are shared by every account and untouched.
-- My sessions disappeared after signing out, an update, or a reset. Is this the fix? Only when the records still exist under another account or organization. If a reset or update deleted them there is nothing to move, the transcripts survive and `claude --resume` in the terminal still lists them, and the sidebar needs its records rebuilt.
-- Do I have to move history back when I return to the first account? Yes, it is a move, not a copy. Moving back is the same one click and takes seconds to a minute, longer only when a Desktop restart is needed.
-- Can I continue the same session under the other account? Yes. It keeps its id, and the next message goes through the account you are signed into with the whole conversation as context. Personal history moved into a Team or Enterprise organization becomes that organization's data.
+### Why is the Code sidebar empty after switching accounts?
+
+Desktop keeps one record per session under `~/Library/Application Support/Claude/claude-code-sessions/<account>/<organization>` and lists only the signed-in folder. The transcripts in `~/.claude/projects` are shared by every account and untouched.
+
+### My sessions disappeared after signing out, an update, or a reset. Is this the fix?
+
+Only when the records still exist under another account or organization. If a reset or update deleted them there is nothing to move, the transcripts survive and `claude --resume` in the terminal still lists them, and the sidebar needs its records rebuilt.
+
+### Do I have to move history back when I return to the first account?
+
+Yes, it is a move, not a copy. Moving back is the same one click and takes seconds to a minute, longer only when a Desktop restart is needed.
+
+### Can I continue the same session under the other account?
+
+Yes. It keeps its id, and the next message goes through the account you are signed into with the whole conversation as context. Personal history moved into a Team or Enterprise organization becomes that organization's data.
+
+### Can a Team or Enterprise admin see moved history?
+
+Team owners get usage analytics only. Enterprise compliance tooling can retrieve Claude Code session transcripts, and the next message in a moved session sends its whole conversation to that organization.
+
+### Does it work on Windows or Linux?
+
+Not yet. Desktop uses the same per-account folder layout there, under its app data directory, so the CLI needs only the platform paths and process checks, and the menubar stays macOS. PRs welcome, and claude-code-session-restorer covers Windows rebuilds meanwhile.
+
+Shorter answers:
+
 - Does a move use tokens or talk to a model? No. Continuing a moved session costs the same as resuming any session after a break, and the prompt cache is per organization, so the first message after a switch never hits it either way.
 - Which plans and accounts work? Any plan that runs Claude Code in Claude Desktop, Pro, Max, Team, or Enterprise. Two organizations on one email, a Team seat next to a personal plan, are two sidebars and both are supported.
-- Can a Team or Enterprise admin see moved history? Team owners get usage analytics only. Enterprise compliance tooling can retrieve Claude Code session transcripts, and the next message in a moved session sends its whole conversation to that organization.
 - What happens to sessions that are running when I switch? Desktop ends the workers of the account you leave. Sessions with a running worker are held until you approve a restart, or skipped with Move only the rest.
 - Is anything uploaded or read from Keychain? From the CLI, not unless you pass `--cloud`. The menubar's Move always passes it: Desktop's claude.ai session is read from Keychain in memory, sent only to claude.ai to reconcile Remote Control mirrors, and never stored.
 - What about Remote Control and cloud sessions? They stay with the account that created them. `--cloud` archives the source's mirrors after the local copy verifies, and you re-enable Remote Control per session under the new account.
@@ -130,7 +151,6 @@ Command and flag names are stable. Renames get a deprecation release first.
 - Does the CLI or the VS Code extension have this problem? The CLI does not, `claude --resume` reads the shared transcripts regardless of login. The VS Code extension keeps its own session index, untested and not handled here.
 - What about Claude chats and Projects? Those live on claude.ai per organization and are not touched.
 - Can I do it by hand? Yes. Quit Desktop, move the session's record file into the other account's organization folder, reopen Desktop. Do it only while Desktop is closed, it rewrites records it has open from memory.
-- Windows or Linux? Not yet. Desktop uses the same per-account folder layout there, under its app data directory, so the CLI needs only the platform paths and process checks, and the menubar stays macOS. PRs welcome, and claude-code-session-restorer covers Windows rebuilds meanwhile.
 
 Anthropic issues that describe the same problem: [74662](https://github.com/anthropics/claude-code/issues/74662) tracks the per-account scoping, [85294](https://github.com/anthropics/claude-code/issues/85294) the root cause, [26452](https://github.com/anthropics/claude-code/issues/26452) and [48511](https://github.com/anthropics/claude-code/issues/48511) the disappearing sessions, [18435](https://github.com/anthropics/claude-code/issues/18435) and [30031](https://github.com/anthropics/claude-code/issues/30031) the request for account profiles.
 

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "type": "git",
     "url": "git+https://github.com/vitaliyhayda/claude-transplant.git"
   },
-  "homepage": "https://github.com/vitaliyhayda/claude-transplant#readme",
+  "homepage": "https://vitaliyhayda.github.io/claude-transplant/",
   "bugs": "https://github.com/vitaliyhayda/claude-transplant/issues",
   "keywords": [
     "claude",
@@ -43,5 +43,6 @@
   "license": "MIT",
   "os": [
     "darwin"
-  ]
+  ],
+  "author": "Vitaliy Hayda (https://github.com/vitaliyhayda)"
 }


### PR DESCRIPTION
Three discoverability items.

- The six most-searched FAQ entries become question headings with the answer as the first paragraph, the form answer engines cite. The other nine stay as a list.
- A Pages workflow renders README.md into a one-page site at https://vitaliyhayda.github.io/claude-transplant/ on every push to main that touches the README, package.json, or the workflow. Python-Markdown with tables, fenced code, heading ids, and markdown inside the collapsible blocks. Title, description, canonical, and Open Graph tags come from package.json. Pages is already enabled on the repo in workflow mode, so the first deploy runs on merge.
- package.json gains an author and points homepage at the site, which npm counts as a custom website.

No code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)