### PR TITLE
label logins held in claude-acc account directories

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ To    ↑↓ move · enter confirm
 - cloud checks pending: inaccessible sources that still have unreadable or unarchived local records
 - newer cloud sessions: rows created after Move, left for the next move
 
-Accounts are labeled from `~/.claude.json`, its backups, `~/.claude*` profile directories, and Desktop's agent-mode records. Personal-plan organizations show as Personal. Accounts with no known email show a uuid prefix, session count, last activity, and most common project folder.
+Accounts are labeled from `~/.claude.json`, its backups, `~/.claude*` profile directories, `~/.claude-switch/accounts/*` config directories, and Desktop's agent-mode records. Personal-plan organizations show as Personal. Accounts with no known email show a uuid prefix, session count, last activity, and most common project folder.
 
 Active identity comes from the newest complete initialization entry in Claude Desktop's `main.log` for the current Desktop process. A logout, unfinished switch, initialization failure, or config conflict clears it and the panel shows unknown. No Keychain access or network request is used for the badge. Desktop must be running.
 

--- a/transplant.js
+++ b/transplant.js
@@ -345,6 +345,7 @@ export function layout(home = os.homedir()) {
     pool: path.join(home, '.claude/projects'),
     login: path.join(home, '.claude.json'),
     backups: path.join(home, '.claude/backups'),
+    switchAccounts: path.join(home, '.claude-switch/accounts'),
     state: path.join(support, 'claude-transplant')
   }
 }
@@ -540,6 +541,9 @@ async function logins(paths) {
   }
   for (const e of await readdir(paths.home, { withFileTypes: true }).catch(() => [])) {
     if (e.name.startsWith('.claude')) await take(e.isDirectory() ? path.join(paths.home, e.name, '.claude.json') : path.join(paths.home, e.name))
+  }
+  for (const e of await readdir(paths.switchAccounts, { withFileTypes: true }).catch(() => [])) {
+    if (e.isDirectory()) await take(path.join(paths.switchAccounts, e.name, '.claude.json'))
   }
   for (const f of await readdir(paths.backups).catch(() => [])) if (f.startsWith('.claude.json.backup')) await take(path.join(paths.backups, f))
   await take(paths.login)

--- a/transplant.test.js
+++ b/transplant.test.js
@@ -1783,6 +1783,20 @@ test('accounts includes a known login organization with no Desktop directory', a
   assert.equal(await stat(row.dir).then(() => true, () => false), false)
 })
 
+test('accounts labels a login held in a claude-acc account directory', async () => {
+  const h = await home()
+  const account = id(922)
+  const org = id(923)
+  const profile = path.join(h.paths.switchAccounts, 'work')
+  await mkdir(profile, { recursive: true })
+  await writeFile(path.join(profile, '.claude.json'), JSON.stringify({
+    oauthAccount: { accountUuid: account, organizationUuid: org, emailAddress: 'switched@example.com', organizationName: 'Switched Team', organizationType: 'team' }
+  }))
+  const row = (await accounts(h.paths)).find((candidate) => candidate.account === account && candidate.org === org)
+
+  assert.equal(row.label, 'switched@example.com \u00b7 Switched Team')
+})
+
 test('menubar snapshot renders live accounts without installing', async () => {
   const h = await home()
   const output = path.join(h.root, 'snapshot', 'panel.png')


### PR DESCRIPTION
`logins()` walks `$HOME` for entries named `.claude*` and, for a directory, reads `<dir>/.claude.json`. [claude-acc](https://github.com/Nemo-Illusionist/claude-code-account-switcher) keeps one `CLAUDE_CONFIG_DIR` per account a level deeper than that:

```
~/.claude-switch/accounts/work/.claude.json
~/.claude-switch/accounts/personal/.claude.json
```

So `~/.claude-switch/` is visited, has no `.claude.json` of its own, and the accounts inside it are never seen. On a machine that switches accounts by config directory — the case `claude-transplant` is most useful on, since that is how history ends up under the wrong account in the first place — every one of those accounts falls back to a uuid prefix in both the picker and the menubar, even though the email and organization are sitting right there on disk.

This adds `switchAccounts` to `layout()` and one loop over it in `logins()`, reusing the existing `take`. No new file, no comments, no behaviour change when the directory is absent (`readdir` already falls back to `[]`).

## Verified

- `npm test` on Node 22.20.0, macOS 15.6 (Darwin 25.6.0): 172 pass, 0 fail
- The added test fails without the two-line change (`TypeError: Cannot read properties of undefined (reading 'label')`) and passes with it
- The layout it reads is claude-acc 0.17.0; `oauthAccount.emailAddress` / `organizationUuid` land in that file the same way Claude Code 2.1.263 writes `~/.claude.json`, because it is the same file written under a different `CLAUDE_CONFIG_DIR`

## Not done

Only the account **labels**. Session records still come from `~/Library/Application Support/Claude/claude-code-sessions`, and the transcript pool is still `~/.claude/projects` — a claude-acc account has its own `projects` directory under its config dir, so moves involving those transcripts are a separate question I have not touched here.