### PR TITLE
fix: move task families and unblock pending completion

### DIFF
--- a/README.md
+++ b/README.md
@@ -274,6 +274,7 @@ Active identity comes from the newest complete initialization entry in Claude De
 
 | claude-transplant | macOS | Claude Desktop | Claude Code | Tested |
 |---|---|---|---|---|
+| 4.0.6 | 27.0 | 1.52386.3 | 2.1.266 | 2026-09-12 |
 | 4.0.5 | 27.0 | 1.49585.0 | 2.1.260 | 2026-09-08 |
 | 4.0.4 | 27.0 | 1.46388.4 | 2.1.260 | 2026-09-08 |
 | 4.0.3 | 27.0 | 1.46388.4 | 2.1.260 | 2026-09-07 |

--- a/README.md
+++ b/README.md
@@ -97,16 +97,16 @@ To    ↑↓ move · enter confirm
 |---|---|
 | `claude-transplant` | pick From and To, move, print a receipt |
 | `--dry-run` | plan only, write nothing |
-| `undo` | quarantine the last move and restore source entries, refused if a target changed or a source cannot be restored |
-| `finish` | finish held local records or active-source cloud checks, continue a staged cloud undo, and list sessions the last move refused |
+| `undo` | quarantine the last move and restore source entries and task registrations, refused if a target changed or a source cannot be restored |
+| `finish` | recover interrupted task transfers, finish held local records or active-source cloud checks, continue a staged undo, and list earlier refusals as information |
 | `sweep` | verify placed records and retry eligible pending work, never requests a restart |
 | `restart` | show the plan for the existing Desktop refresh action |
-| `keep-local` | cancel held work and pending cloud checks without reversing completed moves |
+| `keep-local` | cancel remaining work and cloud checks, keep completed moves |
 | `accounts` | list accounts |
 | `menubar` | install the menubar app (`--snapshot <png>`, `--remove`) |
 | `--from <match> --to <match>` | skip the picker, repeat `--from`, match on email, org name, or uuid prefix |
 | `--move-only` | move eligible records, leave Desktop-owned records held |
-| `--restart-approved <token>` | approve the exact plan printed by the prior move, finish, or restart call |
+| `--restart-approved <token>` | approve the exact restart plan printed for the requested operation |
 | `--cloud` | reconcile the active source, queue inaccessible sources that still have unreadable or unarchived local records |
 | `--json` | one event per line |
 | `--version` | print the version |
@@ -119,8 +119,8 @@ Every command may write the tool's own files under `~/Library/Application Suppor
 |---|---|
 | `accounts`, `--dry-run`, `--version`, `keep-local` | nothing, `--dry-run --cloud` also reads Remote Control metadata over the network |
 | `restart` without a token | nothing beyond the recovery above |
-| move, `finish`, `sweep`, `undo` | Desktop session records under `claude-code-sessions` |
-| `--restart-approved <token>` | quits and reopens Claude Desktop, then the same as a move |
+| move, `finish`, `sweep`, `undo` | Desktop session records and scheduled task registries under `claude-code-sessions` |
+| `--restart-approved <token>` | quits and reopens Claude Desktop around the requested operation |
 | a move with `--cloud`, and `finish`, `sweep`, `undo`, or `restart` while the receipt has pending or staged cloud work | Desktop's claude.ai session read from Keychain in memory, network to `claude.ai` only, Remote Control mirrors archived or restored there, rescued local transcripts when a remote branch diverged |
 | `menubar`, `menubar --remove` | the app bundle in the tool's folder and a LaunchAgent under `~/Library/LaunchAgents` |
 | Move in the menubar | the same as a move with `--cloud`, the panel always passes it |
@@ -180,7 +180,7 @@ Eligibility:
 
 - history is a single comparable version
 - record filename and identity are valid
-- no scheduled task, notification route, or running worker owns it
+- no running worker owns it, and any task registrations, generated runs, notification routes, parents, and forks form a complete movable family
 - parent record is already in the target or moves first in the same batch, and stays wherever surviving forks refer to it, including archived forks or forks without history
 - no id collision in the target
 
@@ -189,7 +189,7 @@ Worker identity uses the Desktop record id, CLI session id, PID, process start t
 Restarts:
 
 - When an operation needs Desktop to close, the engine emits a plan first. The menubar warns which Code workers, windows, Chat, Cowork, and background commands will close.
-- Stop and restart approves that exact process inventory. A changed inventory invalidates approval. Cold moves show no dialog.
+- Stop and restart approves that exact process inventory. A changed inventory invalidates approval. Task registry changes require Desktop to be stopped or a known inactive account and organization. An active or unknown scheduler requires this plan even without a worker. Cold moves show no dialog.
 - An approved restart sends a graceful quit, waits for Desktop and its descendants to exit, moves the held records, and reopens Desktop. 30 second budget, no force kill, no cloud work in that window. A veto or missed deadline leaves held records untouched.
 - Background retries never start a new shutdown.
 
@@ -204,7 +204,7 @@ Safety:
 
 - One receipt owns the move, held records, cloud checks, failures, and retries. Another move cannot start until it is complete, kept local, or undone.
 - Records are written to a private temp inode, journaled, then exposed by an atomic no-clobber hard link. A record is either absent or complete.
-- Interrupted retirement or undo resumes from the receipt. A corrupt newest receipt stops undo.
+- Interrupted retirement or undo resumes from the receipt. Finish move exposes interrupted task recovery and offers restart approval when the scheduler is active. Task families keep task ids, schedules, enabled and last-run state, skip history, retry state, shared prompt paths and bytes, and unrelated registry fields, with selected scheduling state and records restored together. A corrupt newest receipt stops undo.
 - Later moves and sweeps report changes to title, archive state, and starred state under `drift/<receipt>`. Other Desktop bookkeeping stays quiet. Missing or unreadable records retain a warning. Undo, retirement, and source archival also ignore branch and PR bookkeeping.
 - Background checks keep the panel enabled. A click captures its command and selection, shows a waiting state, and cannot be replaced by another action before the check finishes.
 - Lineage follows `forkedFrom` pointers to their roots. Duplicate message ids count as sync replays when only runtime metadata differs, or an otherwise identical copy leaves command output or file-read content empty. Conflicting contents are refused.
@@ -218,8 +218,8 @@ Safety:
 - compatible source versions: same history in several transcript files without an explicit Desktop fork, blocked unless the target already holds every version
 - overlapping versions: shared lineage kept separate, including Desktop forks with separate transcripts
 - already there: a compatible Desktop record in the target holds every message and sidecar file
-- held: a Desktop worker owns a required record, restart approval is offered
-- blocked: needs merging, has a collision or unresolved parent, or is owned by a scheduled task, notification route, or external CLI worker
+- held: a Desktop worker or scheduler owns required records, restart approval is offered
+- blocked: needs merging, has a collision or unresolved parent, has an incomplete task family, or is owned by an external CLI worker
 - retired: source entries moved to quarantine after verification
 - cloud mirrors: active or paused Remote Control rows under the signed-in source
 - cloud rescue: one divergent remote branch materialized as a separate local session from exact message payloads

--- a/README.md
+++ b/README.md
@@ -164,7 +164,7 @@ Shorter answers:
 - Can I undo? Yes. `undo` puts every record back, all or nothing, and refuses if a moved session changed on the target side, is still open, or a new fork still needs the moved parent.
 - Does the CLI or the VS Code extension have this problem? The CLI does not, `claude --resume` reads the shared transcripts regardless of login. The VS Code extension keeps its own session index, untested and not handled here.
 - What about Claude chats and Projects? Those live on claude.ai per organization and are not touched.
-- Can I do it by hand? Yes. Quit Desktop, move the session's record file into the other account's organization folder, reopen Desktop. Do it only while Desktop is closed, it rewrites records it has open from memory.
+- Can I do it by hand? For task-free sessions, quit Desktop, move the record file into the other account's organization folder, then reopen Desktop. Do it only while Desktop is closed, it rewrites records it has open from memory.
 
 Anthropic issues that describe the same problem: [74662](https://github.com/anthropics/claude-code/issues/74662) tracks the per-account scoping, [85294](https://github.com/anthropics/claude-code/issues/85294) the root cause, [26452](https://github.com/anthropics/claude-code/issues/26452) and [48511](https://github.com/anthropics/claude-code/issues/48511) the disappearing sessions, [18435](https://github.com/anthropics/claude-code/issues/18435) and [30031](https://github.com/anthropics/claude-code/issues/30031) the request for account profiles.
 
@@ -189,7 +189,7 @@ Worker identity uses the Desktop record id, CLI session id, PID, process start t
 Restarts:
 
 - When an operation needs Desktop to close, the engine emits a plan first. The menubar warns which Code workers, windows, Chat, Cowork, and background commands will close.
-- Stop and restart approves that exact process inventory. A changed inventory invalidates approval. Task registry changes require Desktop to be stopped or a known inactive account and organization. An active or unknown scheduler requires this plan even without a worker. Cold moves show no dialog.
+- Stop and restart approves that exact process inventory. A changed inventory invalidates approval. Task registry changes require Desktop to be stopped or both source and target account/organization pairs to be known inactive. An active or unknown scheduler requires this plan even without a worker. Other cold moves show no dialog.
 - An approved restart sends a graceful quit, waits for Desktop and its descendants to exit, moves the held records, and reopens Desktop. 30 second budget, no force kill, no cloud work in that window. A veto or missed deadline leaves held records untouched.
 - Background retries never start a new shutdown.
 
@@ -204,7 +204,7 @@ Safety:
 
 - One receipt owns the move, held records, cloud checks, failures, and retries. Another move cannot start until it is complete, kept local, or undone.
 - Records are written to a private temp inode, journaled, then exposed by an atomic no-clobber hard link. A record is either absent or complete.
-- Interrupted retirement or undo resumes from the receipt. Finish move exposes interrupted task recovery and offers restart approval when the scheduler is active. Task families keep task ids, schedules, enabled and last-run state, skip history, retry state, shared prompt paths and bytes, and unrelated registry fields, with selected scheduling state and records restored together. A corrupt newest receipt stops undo.
+- Interrupted retirement or undo resumes from the receipt. Finish move exposes interrupted task recovery and offers restart approval when the scheduler is active. Task families preserve reminders, run history, prompts and unrelated settings. Recovery rolls back only unfinished families. Undo restores the whole move. A corrupt newest receipt stops undo.
 - Later moves and sweeps report changes to title, archive state, and starred state under `drift/<receipt>`. Other Desktop bookkeeping stays quiet. Missing or unreadable records retain a warning. Undo, retirement, and source archival also ignore branch and PR bookkeeping.
 - Background checks keep the panel enabled. A click captures its command and selection, shows a waiting state, and cannot be replaced by another action before the check finishes.
 - Lineage follows `forkedFrom` pointers to their roots. Duplicate message ids count as sync replays when only runtime metadata differs, or an otherwise identical copy leaves command output or file-read content empty. Conflicting contents are refused.
@@ -236,7 +236,7 @@ Active identity comes from the newest complete initialization entry in Claude De
 
 - Rehome local history or refuse. Never duplicate a local transcript, never merge histories.
 - No transcript or sidecar is renamed, edited, or deleted. The quarantined record is the rollback.
-- Cold moves need no confirmation. Desktop restarts require exact plan approval or the saved warning preference.
+- Moves with no active worker or affected scheduler need no confirmation. Desktop restarts require exact plan approval or the saved warning preference.
 - Remote rescue copies payloads exactly. No model reconstructs history.
 - Remote Control is touched only with `--cloud`, with no credential persistence.
 - Automatic retries cover the receipt's named work only. They never start a restart, store credentials, or create destination bridges.

--- a/menubar.swift
+++ b/menubar.swift
@@ -20,6 +20,7 @@ struct Account: Decodable, Identifiable {
     var receiptMoved: Int? = nil
     var receiptDestination: String? = nil
     var receipt: String? = nil
+    var recoveryProblem: RecoveryProblem? = nil
     var id: String { account + "/" + org }
     var selector: String { account + " " + org }
     var name: String { email ?? String(account.prefix(8)) }
@@ -34,6 +35,11 @@ struct Config: Decodable {
 struct Failure: Decodable {
     let id: String?
     let title: String?
+    let error: String
+}
+
+struct RecoveryProblem: Decodable {
+    let receipt: String
     let error: String
 }
 
@@ -292,10 +298,12 @@ final class Model: ObservableObject {
     var identityLabel: String? { accounts.contains { $0.active == true } ? nil : accounts.first?.identityState == "logged-out" ? "signed out" : "unknown" }
     var pendingAccounts: [Account] { accounts.filter { $0.pending != nil } }
     var activePendingAccount: Account? { pendingAccounts.first { $0.active == true } }
-    var canKeepLocal: Bool { !running && pendingAccounts.contains { ["cloud", "local"].contains($0.pending ?? "") } }
-    var pendingReady: Bool { !running && pendingAccounts.contains { ["finish", "restart"].contains($0.pendingAction ?? ($0.pending == "local" || $0.active == true ? "finish" : "sign-in")) } && (config != nil || demo) }
+    var recoveryProblem: RecoveryProblem? { accounts.compactMap(\.recoveryProblem).first }
+    var canMutate: Bool { !running && recoveryProblem == nil }
+    var canKeepLocal: Bool { canMutate && pendingAccounts.contains { ["cloud", "local"].contains($0.pending ?? "") } }
+    var pendingReady: Bool { canMutate && pendingAccounts.contains { ["finish", "restart"].contains($0.pendingAction ?? ($0.pending == "local" || $0.active == true ? "finish" : "sign-in")) } && (config != nil || demo) }
     var pendingButtonTitle: String { pendingAccounts.contains { $0.pendingAction == "restart" } ? "Stop and restart" : pendingAccounts.contains { $0.pending == "undo" } ? "Finish Undo" : "Finish move" }
-    var ready: Bool { !running && pendingAccounts.isEmpty && !from.isEmpty && to != nil && (config != nil || demo) }
+    var ready: Bool { canMutate && pendingAccounts.isEmpty && !from.isEmpty && to != nil && (config != nil || demo) }
     var pendingPrompt: String {
         guard !pendingAccounts.isEmpty else { return "" }
         if pendingAccounts.contains(where: { $0.pending == "recovery" }) { return "Finish the interrupted move" }
@@ -311,15 +319,16 @@ final class Model: ObservableObject {
         return parts.isEmpty ? "Remaining sessions are ready to move" : parts.joined(separator: ", ")
     }
     var detailLines: [(String, String)] {
-        if !lines.isEmpty { return lines }
-        return pendingAccounts.flatMap { account in
+        let recovery = recoveryProblem.map { [("recovery", $0.error.sentence), ("receipt", $0.receipt)] } ?? []
+        if !lines.isEmpty { return recovery + lines }
+        return recovery + pendingAccounts.flatMap { account in
             (account.pendingWaiting ?? []).map { ("open", $0.title) } +
             (account.pendingFailures ?? []).map { ("issue", identity($0.title, $0.id) + " | " + $0.error) }
         }
     }
-    var displaySummary: String { running ? progressLabel : note.isEmpty ? pendingPrompt : note }
+    var displaySummary: String { recoveryProblem != nil ? "The move receipt needs repair" : running ? progressLabel : note.isEmpty ? pendingPrompt : note }
     var visibleCompletion: (summary: String, detail: String)? {
-        !running && completion?.summary == note ? completion : nil
+        canMutate && completion?.summary == note ? completion : nil
     }
 
     func canSource(_ account: Account) -> Bool { account.id != to }
@@ -406,7 +415,7 @@ final class Model: ObservableObject {
     }
 
     func undo() {
-        guard !running else { return }
+        guard canMutate else { return }
         start(["undo", "--json"])
     }
 
@@ -521,7 +530,7 @@ final class Model: ObservableObject {
     }
 
     func restartDesktop() {
-        guard !running else { return }
+        guard canMutate else { return }
         start(["restart", "--json"])
     }
 
@@ -587,7 +596,7 @@ final class Model: ObservableObject {
     }
 
     private func sweep() {
-        guard !running, !sweeping, !snapshot else { return }
+        guard canMutate, !sweeping, !snapshot else { return }
         sweeping = true
         var result: Event?
         run(["sweep", "--json"], line: { line in
@@ -961,7 +970,7 @@ struct Panel: View {
                 Spacer()
                 Button(action: { model.refresh() }) { Image(systemName: "arrow.clockwise") }.buttonStyle(.plain).foregroundStyle(.secondary)
             }
-            accountBoard.disabled(model.running || !model.pendingAccounts.isEmpty)
+            accountBoard.disabled(!model.canMutate || !model.pendingAccounts.isEmpty)
             if !model.displaySummary.isEmpty { Divider() }
             if model.running {
                 Bar(value: model.moveProgress.value)
@@ -988,6 +997,7 @@ struct Panel: View {
             }
             if model.restartAvailable {
                 Button(action: { model.restartDesktop() }) { Text("Restart Claude Desktop to see them").font(.callout.weight(.medium)).underline() }.buttonStyle(.plain)
+                    .disabled(!model.canMutate)
             }
             HStack(spacing: 10) {
                 if model.pendingAccounts.isEmpty {
@@ -996,7 +1006,7 @@ struct Panel: View {
                     if model.pendingReady { Pill(title: model.pendingButtonTitle, prominent: true, enabled: true) { model.finishPending() } }
                     if model.canKeepLocal { Pill(title: "Keep completed", prominent: false, enabled: model.canKeepLocal) { model.keepLocal() } }
                 }
-                Pill(title: "Undo last", prominent: false, enabled: !model.running) { model.undo() }
+                Pill(title: "Undo last", prominent: false, enabled: model.canMutate) { model.undo() }
                 Spacer()
                 Button("Quit") { NSApplication.shared.terminate(nil) }.buttonStyle(.plain).foregroundStyle(.secondary)
             }
@@ -1210,7 +1220,7 @@ struct TransplantApp: App {
         MenuBarExtra {
             Panel().environmentObject(model).environment(\.controlActiveState, .key).environment(\.colorScheme, .dark)
         } label: {
-            MenuLabel(symbol: model.symbol, badge: model.badge)
+            MenuLabel(symbol: model.recoveryProblem == nil ? model.symbol : "exclamationmark.triangle", badge: model.recoveryProblem == nil ? model.badge : "")
                 .help(model.running ? "Estimated completion" : "Claude Transplant")
         }
         .menuBarExtraStyle(.window)

--- a/menubar.swift
+++ b/menubar.swift
@@ -102,6 +102,7 @@ struct Event: Decodable {
     let pendingUndo: [String]?
     let retired: Int?
     let failed: [Failure]?
+    let notMoved: [Failure]?
     let problems: [Problem]?
     let note: String?
     let restart: Bool?
@@ -297,6 +298,7 @@ final class Model: ObservableObject {
     var ready: Bool { !running && pendingAccounts.isEmpty && !from.isEmpty && to != nil && (config != nil || demo) }
     var pendingPrompt: String {
         guard !pendingAccounts.isEmpty else { return "" }
+        if pendingAccounts.contains(where: { $0.pending == "recovery" }) { return "Finish the interrupted move" }
         let moved = pendingAccounts.compactMap(\.receiptMoved).max() ?? 0
         let waiting = Set(pendingAccounts.flatMap { $0.pendingWaiting ?? [] }.map(\.id)).count
         let issues = pendingAccounts.reduce(0) { $0 + ($1.pendingFailures?.count ?? 0) }
@@ -505,6 +507,7 @@ final class Model: ObservableObject {
     }
 
     private func recordIssues(_ event: Event) {
+        if let notMoved = event.notMoved, !notMoved.isEmpty { lines.append(("not moved", notMoved.map { identity($0.title, $0.id) + " | " + $0.error }.joined(separator: "\n"))) }
         if let failed = event.failed, !failed.isEmpty { lines.append(("issue", failed.map { identity($0.title, $0.id) + " | " + $0.error }.joined(separator: "\n"))) }
         for problem in event.problems ?? [] { lines.append(("check", identity(problem.title, problem.id) + " | " + problem.check + " verification failed")) }
     }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-transplant",
-  "version": "4.0.5",
+  "version": "4.0.6",
   "description": "Claude Desktop shows an empty Code sidebar after you switch accounts. This moves the session history to the account you are using. macOS, menubar or CLI.",
   "type": "module",
   "bin": {

--- a/transplant.js
+++ b/transplant.js
@@ -1988,7 +1988,7 @@ async function writeTaskRegistrations(transfers, side, present, paths, inspect, 
     }
     if (!present && side === 'target' && !family.targetHadTasks && !next.length) delete after.scheduledTasks
     const remove = !present && side === 'target' && !family.targetExisted && !Object.keys(after).length
-    if (remove) await unlink(file)
+    if (remove) await unlink(file).catch(error => { if (error.code !== 'ENOENT') throw error })
     else await saveText(file, jsonText(after), async () => {
       const problems = await taskTransferProblems([family], paths, inspect, true, check)
       if (problems.length) throw new Error(problems.join(', '))
@@ -3565,11 +3565,13 @@ async function completeActiveCloud(result, paths, options = {}) {
 }
 
 export async function finishWorkflow(paths, options = {}) {
+  const approving = options.approve != null
+  if (approving && (typeof options.approve !== 'string' || !/^[a-f0-9]{64}$/.test(options.approve))) return { ok: false, reason: 'Restart approval is missing or does not match the saved plan' }
   const recovery = await recoveryPending(paths)
   if (recovery) {
     const taskTransfers = recovery.receipt ? recoveryFamilies(recovery.receipt) : []
     if (!options.background && taskTransfers.length && !recovery.receipt.remotePending && !recovery.receipt.remoteUndoing?.length &&
-      (options.approve || await schedulerBusy(paths, taskTransfers.flatMap(row => [row.from, row.to]), options.io?.inspect?.() ?? options.processes))) {
+      (approving || await schedulerBusy(paths, taskTransfers.flatMap(row => [row.from, row.to]), options.io?.inspect?.() ?? options.processes))) {
       return executeMove(null, null, paths, { ...options, recover: true, receiptFile: recovery.file })
     }
     return finishPending(paths, options)
@@ -3579,7 +3581,7 @@ export async function finishWorkflow(paths, options = {}) {
   const deferred = await deferredWorkflow(paths)
   if (deferred?.mode === 'local') return completeActiveCloud(await finishHeld(paths, options), paths, options)
   if (deferred?.mode === 'undo') return finishPending(paths, options)
-  if (options.approve) {
+  if (approving) {
     if (!deferred || deferred.mode !== 'cloud') return { ok: false, reason: 'The pending move changed before its restart' }
     const restarted = await executeMove(null, null, paths, { ...options, finish: true, receiptFile: deferred.file })
     if (!restarted.ok || restarted.plan) return restarted
@@ -3923,7 +3925,7 @@ function parse(argv) {
   const incompatible = args.from.length || args.to || args.dry || args.cloud || args.remove || args.snapshot
   if (['accounts', 'keep-local', 'sweep'].includes(args.cmd) && (incompatible || args.restartApproved || args.moveOnly)) throw new Error(`${args.cmd} accepts only --json`)
   if (['finish', 'undo'].includes(args.cmd) && (incompatible || args.cmd === 'undo' && args.moveOnly)) throw new Error(`${args.cmd} accepts only --json and --restart-approved`)
-  if (args.restartApproved && !/^[a-f0-9]{64}$/.test(args.restartApproved)) throw new Error('restart approval token must be the one displayed by the engine')
+  if (args.restartApproved != null && !/^[a-f0-9]{64}$/.test(args.restartApproved)) throw new Error('restart approval token must be the one displayed by the engine')
   if (args.moveOnly && (args.restartApproved || args.dry || (args.cmd && args.cmd !== 'finish'))) throw new Error('--move-only applies only to a move or held continuation')
   if (args.restartApproved && (args.dry || (args.cmd && !['restart', 'finish', 'undo'].includes(args.cmd)))) throw new Error('restart approval applies only to a move, finish, undo, or restart')
   if (args.cmd === 'restart' && incompatible) throw new Error('restart accepts only --json and --restart-approved')

--- a/transplant.js
+++ b/transplant.js
@@ -71,7 +71,19 @@ const waitingSessions = (receipt) => [...new Map([
 ].map(row => [row.localId ?? remoteId(row.id) ?? row.id, row])).values()]
 const legacyLocalFailures = (receipt) => receipt.localCancelledAt ? [] : (receipt.failed ?? []).filter(row => row.error === WORKER_OWNS && UUID.test(row.id ?? ''))
 const needsRecovery = (receipt) => Boolean(receipt.pending || receipt.retiring || receipt.finalizing || receipt.undoing || receipt.remotePending || receipt.remoteUndoing?.length)
-const recoveryFamilies = (receipt) => (receipt.taskTransfers ?? []).slice(receipt.undoing ? 0 : receipt.appendCheckpoint?.taskTransfers ?? 0)
+const recoveryFamilies = (receipt) => {
+  const transfers = receipt.taskTransfers ?? [], checkpoint = receipt.appendCheckpoint
+  if (!checkpoint) return transfers
+  if (['sessions', 'superseded'].some(key => !Number.isSafeInteger(checkpoint[key]) || checkpoint[key] < 0 || checkpoint[key] > (receipt[key]?.length ?? 0)) || !Array.isArray(checkpoint.held)) throw new Error('invalid append checkpoint')
+  if (receipt.undoing) return transfers
+  const offset = checkpoint.taskTransfers === undefined && !transfers.length ? 0 : checkpoint.taskTransfers
+  if (!Number.isSafeInteger(offset) || offset < 0 || offset > transfers.length) throw new Error('invalid append checkpoint')
+  const committed = (receipt.sessions ?? []).slice(0, checkpoint.sessions).filter(row => row.taskFamily).map(row => [row.taskFamily, row.targetRecordId])
+  const expected = transfers.slice(0, offset).flatMap(family => family.recordIds.map(id => [family.key, id]))
+  const retired = new Set((receipt.superseded ?? []).slice(0, checkpoint.superseded).filter(row => row.source).flatMap(row => row.moved.map(([file]) => file)))
+  if (stable(committed.sort()) !== stable(expected.sort()) || transfers.some((family, index) => family.files.some(file => retired.has(file) !== (index < offset)))) throw new Error('invalid append checkpoint')
+  return transfers.slice(offset)
+}
 const inspector = (paths, options) => options.inspect ?? options.io?.inspect ?? (() => options.processes ?? processTable(paths.claudeApp))
 const receiptOkay = (receipt) => receipt.verification?.ok !== false && !receipt.failed?.length
 const finishOkay = (receipt) => receipt.verification?.ok !== false && !receipt.verification?.problems?.length &&
@@ -2131,11 +2143,9 @@ async function reconcileFiles(paths, options = {}) {
   }
   const { receipt } = p
   const inspect = inspector(paths, options)
-  const checkpoint = receipt.appendCheckpoint
   const taskTransfers = recoveryFamilies(receipt)
   const taskProblems = await taskTransferProblems(taskTransfers, paths, inspect, true, options.check)
   if (taskProblems.length && !(receipt.undoing && receipt.remoteUndoing?.length && taskProblems.every(problem => problem === SCHEDULER_OWNS) && !options.check)) return { title: 'scheduled task recovery blocked', error: taskProblems.join(', '), problems: taskProblems }
-  if (checkpoint && (!Number.isSafeInteger(checkpoint.sessions) || checkpoint.sessions < 0 || checkpoint.sessions > (receipt.sessions?.length ?? 0) || !Number.isSafeInteger(checkpoint.superseded) || checkpoint.superseded < 0 || checkpoint.superseded > (receipt.superseded?.length ?? 0) || !Array.isArray(checkpoint.held))) return { title: 'recovery blocked', error: 'invalid append checkpoint' }
   receipt.failed ??= []
   receipt.superseded ??= []
   if (receipt.undoing) {

--- a/transplant.js
+++ b/transplant.js
@@ -16,6 +16,8 @@ const UUIDS = new RegExp(UUID_PATTERN, 'gi')
 const LOCAL_RECORD = new RegExp(`^local_${UUID_PATTERN}$`, 'i')
 const NOTE = 'restart Claude Desktop to see them'
 const WORKER_OWNS = 'running worker owns the session'
+const SCHEDULER_OWNS = 'Desktop scheduler requires an approved restart'
+const TASK_STATE_KEYS = ['recordedSkips', 'runRetries']
 const PARENT_MISSING = 'parent Desktop record is absent from the target and move'
 const desktopExecutable = (file) => typeof file === 'string' && file.endsWith('/Claude.app/Contents/MacOS/Claude')
 const RESTART_BUDGET = 30_000
@@ -68,7 +70,10 @@ const waitingSessions = (receipt) => [...new Map([
   ...openCloudChecks(receipt).flatMap(check => check.waiting ?? [])
 ].map(row => [row.localId ?? remoteId(row.id) ?? row.id, row])).values()]
 const legacyLocalFailures = (receipt) => receipt.localCancelledAt ? [] : (receipt.failed ?? []).filter(row => row.error === WORKER_OWNS && UUID.test(row.id ?? ''))
+const needsRecovery = (receipt) => Boolean(receipt.pending || receipt.retiring || receipt.finalizing || receipt.undoing || receipt.remotePending || receipt.remoteUndoing?.length)
 const receiptOkay = (receipt) => receipt.verification?.ok !== false && !receipt.failed?.length
+const finishOkay = (receipt) => receipt.verification?.ok !== false && !receipt.verification?.problems?.length &&
+  !(receipt.failed ?? []).some(row => row.cloudAccount) && !receipt.cloudError
 const problemText = (problem) => `${problem.title ?? problem.id} | ${problem.check} verification failed`
 const cancelCloudChecks = (receipt) => {
   for (const check of openCloudChecks(receipt)) {
@@ -181,7 +186,7 @@ export async function restartPlan(inv, paths, table = processTable(paths.claudeA
   const owned = workerGroups(table).filter(row => row.desktopPid === desktop.pid)
   const matching = (row) => table.filter((worker) => worker.worker && worker.pid !== desktop.pid && (row.members ?? [row]).some((member) => processOwns(worker, member)))
   const stoppable = (rows) => rows.length && rows.every((row) => row.desktopPid === desktop.pid)
-  const release = (row) => ({ ...row, worker: stoppable(matching(row)) ? false : row.worker,
+  const release = (row) => ({ ...row, schedulerBusy: false, worker: stoppable(matching(row)) ? false : row.worker,
     ...(row.members ? { members: row.members.map((member) => ({ ...member, worker: stoppable(matching(member)) ? false : member.worker })) } : {}) })
   const target = inv && all.find((account) => sameAccount(account, inv.toAccount))
   const released = target ? localPlan([...inv.move, ...inv.blocked].map(release), target).move : []
@@ -206,7 +211,7 @@ export async function restartPlan(inv, paths, table = processTable(paths.claudeA
   }
   for (const { row, source } of candidates) {
     const matches = matching(row)
-    if (stoppable(matches)) add(row, source, matches)
+    if (stoppable(matches) || inv.blocked.some(item => item.file === source.file && item.schedulerBusy) && !matches.some(worker => worker.desktopPid !== desktop.pid)) add(row, source, matches)
   }
   let added = true
   while (added && inv) {
@@ -215,7 +220,7 @@ export async function restartPlan(inv, paths, table = processTable(paths.claudeA
       const related = held.find((item) => item.sources.some((member) => {
         const current = inv.sources.find((row) => row.file === member.file)
         return current && (source.members ?? [source]).some((row) => sameAccount(row.account, current.account) &&
-          (row.record.forkedFromSessionId === current.record.sessionId || current.record.forkedFromSessionId === row.record.sessionId))
+          (row.taskFamily && row.taskFamily === current.taskFamily || row.record.forkedFromSessionId === current.record.sessionId || current.record.forkedFromSessionId === row.record.sessionId))
       }))
       if (related) added = add(source, source, related.workers) || added
     }
@@ -525,13 +530,72 @@ async function taskSessions(file) {
   try {
     data = await readJson(file)
   } catch (error) {
-    if (error.code === 'ENOENT') return new Set()
+    if (error.code === 'ENOENT') return Object.assign(new Set(), { registry: null })
     throw new Error(`unreadable scheduled task registry ${file}`)
   }
   if (!data || typeof data !== 'object' || Array.isArray(data)) throw new Error(`invalid scheduled task registry ${file}`)
   if (data.scheduledTasks !== undefined && !Array.isArray(data.scheduledTasks)) throw new Error(`invalid scheduled task registry ${file}`)
-  if (data.scheduledTasks?.some((task) => !task || typeof task !== 'object' || (task.notifySessionId !== undefined && typeof task.notifySessionId !== 'string'))) throw new Error(`invalid scheduled task registry ${file}`)
-  return new Set((data.scheduledTasks ?? []).map((task) => task?.notifySessionId).filter(Boolean))
+  if (TASK_STATE_KEYS.some(key => data[key] !== undefined && (!data[key] || typeof data[key] !== 'object' || Array.isArray(data[key])))) throw new Error(`invalid scheduled task state ${file}`)
+  const tasks = data.scheduledTasks ?? []
+  if (tasks.some(task => !task || typeof task !== 'object' || Array.isArray(task) || typeof task.id !== 'string' || !task.id ||
+    (task.notifySessionId !== undefined && task.notifySessionId !== null && !LOCAL_RECORD.test(task.notifySessionId)))) throw new Error(`invalid scheduled task registry ${file}`)
+  if (new Set(tasks.map(task => task.id)).size !== tasks.length) throw new Error(`scheduled task id collision in ${file}`)
+  return Object.assign(new Set(tasks.map(task => task.notifySessionId).filter(Boolean)), { registry: data })
+}
+
+const taskState = (registry, ids) => Object.fromEntries(TASK_STATE_KEYS.map(key => [key, Object.fromEntries(Object.entries(registry?.[key] ?? {}).filter(([id]) => ids.includes(id)))]))
+const taskStateConflict = (source, target) => TASK_STATE_KEYS.some(key => Object.entries(target[key]).some(([id, value]) => !Object.hasOwn(source[key], id) || stable(source[key][id]) !== stable(value)))
+
+async function schedulerBusy(paths, namespaces, table = processTable(paths.claudeApp)) {
+  if (!table.some(row => desktopExecutable(row.executable))) return false
+  const current = await signedIn(paths, table)
+  return current.state !== 'known' || namespaces.some(row => sameAccount(row, current))
+}
+
+function taskFamilies(from, to, found) {
+  const families = []
+  for (const account of from) {
+    const tasks = account.taskSessions.registry?.scheduledTasks ?? []
+    const records = account.allSessions ?? account.sessions
+    const graph = new Map(), seeds = new Set()
+    const connect = (a, b) => {
+      if (!graph.has(a)) graph.set(a, new Set())
+      if (!graph.has(b)) graph.set(b, new Set())
+      graph.get(a).add(b)
+      graph.get(b).add(a)
+    }
+    for (const task of tasks) {
+      seeds.add(`task:${task.id}`)
+      connect(`task:${task.id}`, task.notifySessionId ? `record:${task.notifySessionId}` : `task:${task.id}`)
+    }
+    for (const { record } of records) {
+      const key = `record:${record.sessionId}`
+      if (record.scheduledTaskId) { seeds.add(key); connect(key, `task:${record.scheduledTaskId}`) }
+      if (record.notifySessionId) { seeds.add(key); connect(key, `record:${record.notifySessionId}`) }
+      if (record.forkedFromSessionId) connect(key, `record:${record.forkedFromSessionId}`)
+    }
+    const visited = new Set()
+    for (const seed of seeds) {
+      if (visited.has(seed)) continue
+      const keys = new Set([seed])
+      for (const key of keys) { visited.add(key); for (const next of graph.get(key) ?? []) keys.add(next) }
+      const ids = [...keys].filter(key => key.startsWith('task:')).map(key => key.slice(5))
+      const recordIds = [...keys].filter(key => key.startsWith('record:')).map(key => key.slice(7))
+      const members = found.filter(row => sameAccount(row.account, account) && recordIds.includes(row.record.sessionId))
+      if (!members.length) continue
+      const family = { key: `${account.account}/${account.org}/${seed}`, from: accountRef(account), to: accountRef(to),
+        sourceFile: account.taskFile, targetFile: to.taskFile, ids, recordIds, files: members.map(row => row.file), links: members.map(row => taskLinks(row.record)),
+        routes: tasks.filter(task => ids.includes(task.id)).map(task => [task.id, task.notifySessionId ?? null]) }
+      family.error = account.taskError ?? to.taskError ?? (account.unreadable.length ? 'unreadable scheduled task family member' :
+        ids.some(id => !tasks.some(task => task.id === id)) || recordIds.length !== members.length ? 'scheduled task family member missing' :
+        (to.taskSessions.registry?.scheduledTasks ?? []).some(task => ids.includes(task.id) || recordIds.includes(task.notifySessionId)) ? 'target scheduled task collision' :
+        taskStateConflict(taskState(account.taskSessions.registry, ids), taskState(to.taskSessions.registry, ids)) ? 'target scheduled task state collision' : null)
+      for (const row of members) row.taskFamily = family
+      families.push(family)
+    }
+  }
+  for (const family of families) if (families.some(other => other !== family && other.ids.some(id => family.ids.includes(id)))) family.error = 'source scheduled task id collision'
+  return families
 }
 
 async function logins(paths) {
@@ -808,7 +872,7 @@ export async function accounts(paths, processes = null) {
     const label = `${email ?? short(account)} · ${orgName ?? short(org)}`
     const base = sessions.length ? `${sessions.length} | ${ago(activeAt)} | ${mode(sessions.map((s) => path.basename(s.cwd)))}` : '0 | -'
     const stats = `${base}${unreadable.length ? ` | ${unreadable.length} unreadable` : ''}${taskError ? ' | task registry unreadable' : ''}`
-    out.push({ account, org, dir, email, orgName, sessions, unreadable, taskFile, taskSessions: scheduled, taskError, activeAt, focusedAt: Math.max(0, ...sessions.map((s) => s.focusedAt)), label, stats, active: false, signedIn: account === cur.account, identityState: cur.state })
+    out.push({ account, org, dir, email, orgName, sessions, allSessions: sessions, unreadable, taskFile, taskSessions: scheduled, taskError, activeAt, focusedAt: Math.max(0, ...sessions.map((s) => s.focusedAt)), label, stats, active: false, signedIn: account === cur.account, identityState: cur.state })
   }
   const mine = out.filter((a) => a.account === cur.account)
   const chosen = mine.find((a) => a.org === cur.org)
@@ -872,7 +936,6 @@ const without = (entry, keys) => {
 }
 
 const recordSemantic = (record) => sha(stable(without(record, RECORD_RUNTIME_KEYS)))
-const keepRecordSemantic = (record) => sha(stable(without(record, [...RECORD_RUNTIME_KEYS, 'title', 'titleSource'])))
 
 const semanticShape = (entry) => stable(without(entry, RUNTIME_KEYS))
 
@@ -1121,12 +1184,14 @@ const carries = (a, b) => Boolean(a.sidecar && b.sidecar && a.sidecar.set.isSubs
 const desktopRecordOf = (row) => row.session?.record ?? row.record ?? {}
 const canShareRecord = (a, b, requiredParents) => {
   const first = desktopRecordOf(a), second = desktopRecordOf(b)
+  if (a.taskFamily || b.taskFamily) return a.taskFamily === b.taskFamily && first.sessionId === second.sessionId && sameAccount(a.account, b.account)
   if (first.sessionId !== second.sessionId && (requiredParents?.has(first.sessionId) || requiredParents?.has(second.sessionId))) return false
   return a.transcript === b.transcript || !(first.forkedFromSessionId || second.forkedFromSessionId)
 }
 const included = (a, b) => canShareRecord(a, b) && historyIncluded(a, b) && carries(a, b)
 const progress = (report, stage, completed, total) => report(stage, `${completed}/${total}`, { live: true, completed, total })
 const desktopFileOf = (row) => typeof row === 'string' ? row : row.session?.file ?? row.file
+const taskLinks = (record) => [record.sessionId, record.cliSessionId, record.scheduledTaskId ?? null, record.notifySessionId ?? null, record.forkedFromSessionId ?? null, record.cwd ?? null, record.originCwd ?? null]
 const bridgeIdsOf = (row) => [row, ...(row.members ?? [])].flatMap((member) => {
   const record = desktopRecordOf(member)
   return [...(member.bridgeIds ?? []), ...(record.bridgeSessionIds ?? [])]
@@ -1254,17 +1319,19 @@ async function cloudInventory(cloud, from, targets, move, cache, report, cutoff 
 }
 
 const rehomeReason = (source, to, targetIds, targetNames) => {
+  if (source.taskFamily?.error || source.account.taskError || to.taskError) return source.taskFamily?.error ?? source.account.taskError ?? to.taskError
   if (new Set(source.members?.map((member) => member.transcript)).size > 1) return 'multiple compatible source versions require merging'
   if (sameAccount(source.account, to)) return 'source and destination are the same'
   if (source.invalid) return `${source.invalid} unparseable lines`
   if (source.conflicts) return `${source.conflicts} conflicting duplicate uuids`
   if (!source.comparable) return 'history cannot be compared safely'
-  if (source.record.scheduledTaskId) return 'scheduled task owns the Desktop record'
-  if (source.record.notifySessionId) return 'notification route owns the Desktop record'
-  if (source.taskOwned) return 'scheduled task registry owns the Desktop record'
+  if (!source.taskFamily && source.record.scheduledTaskId) return 'scheduled task owns the Desktop record'
+  if (!source.taskFamily && source.record.notifySessionId) return 'notification route owns the Desktop record'
+  if (!source.taskFamily && source.taskOwned) return 'scheduled task registry owns the Desktop record'
   if (targetIds.has(source.id)) return 'target session id collision'
   if (targetNames.has(path.basename(source.file))) return 'target Desktop filename collision'
   if ((source.members ?? [source]).some((member) => member.worker)) return WORKER_OWNS
+  if (source.schedulerBusy) return SCHEDULER_OWNS
   return null
 }
 
@@ -1272,6 +1339,10 @@ function localPlan(pending, to) {
   const targetIds = new Set(to.sessions.map((session) => session.id).filter(Boolean))
   const targetNames = new Set([...to.sessions.map((session) => path.basename(session.file)), ...to.unreadable.map((file) => path.basename(file))])
   const reasons = new Map(pending.map((source) => [source, rehomeReason(source, to, targetIds, targetNames)]))
+  for (const source of pending) if (source.taskFamily) {
+    const reason = pending.find(row => row.taskFamily === source.taskFamily && reasons.get(row))
+    if (reason) for (const row of pending.filter(row => row.taskFamily === source.taskFamily)) reasons.set(row, reasons.get(reason))
+  }
   const availableParents = new Set(to.sessions.map((session) => session.record.sessionId).filter(Boolean))
   let added = true
   while (added) {
@@ -1283,6 +1354,9 @@ function localPlan(pending, to) {
         added = true
       }
     }
+  }
+  for (const source of pending) if (source.taskFamily && !availableParents.has(source.record.sessionId)) {
+    for (const row of pending.filter(row => row.taskFamily === source.taskFamily)) if (!reasons.get(row)) reasons.set(row, PARENT_MISSING)
   }
   const blocked = []
   const move = []
@@ -1313,8 +1387,6 @@ export async function inventory(from, to, paths, report = () => {}, options = {}
   check()
   const requestedAt = options.requestedAt ?? new Date().toISOString()
   const cloudRequested = options.cloudRequested === true || Boolean(options.cloud)
-  const brokenTasks = [...from, to].find((account) => account.taskError)
-  if (brokenTasks) throw new Error(`${brokenTasks.label}: ${brokenTasks.taskError}`)
   const workTotal = from.reduce((sum, account) => sum + account.sessions.length, 0) + to.sessions.length
   let completed = 0
   progress(report, 'scan', completed, workTotal)
@@ -1358,6 +1430,11 @@ export async function inventory(from, to, paths, report = () => {}, options = {}
     }
   }
   unreadable.push(...(to.unreadable ?? []).map((file) => ({ file, account: to, target: true })))
+  const families = taskFamilies(from, to, found)
+  for (const family of families) {
+    const busy = await schedulerBusy(paths, [family.from, family.to], ctx.workers.rows)
+    for (const row of found.filter(row => row.taskFamily === family)) row.schedulerBusy = busy
+  }
   const requiredParents = new Set(found.map(row => row.record.forkedFromSessionId).filter(Boolean))
   const ranked = found.toSorted((a, b) => b.roots.size - a.roots.size || b.activeAt - a.activeAt || a.forks - b.forks || a.createdAt - b.createdAt)
   const reps = []
@@ -1419,6 +1496,8 @@ export async function inventory(from, to, paths, report = () => {}, options = {}
   }
   const apart = divergent.size
   const cloudCutoff = options.cloudCutoff ?? (cloudRequested ? requestedAt : null)
+  const brokenTasks = [...from, to].find(account => account.taskError)
+  if (options.cloud && brokenTasks) throw new Error(brokenTasks.taskError)
   const cloudPlan = await cloudInventory(options.cloud, from, targets, options.cloudTargetOnly ? [] : move, cache, report, cloudCutoff, found, options.cloudSessionIds)
   const retiring = new Set([...move, ...there].flatMap((row) => (row.members ?? [row]).map((member) => member.file)))
   const cloudCheckAccounts = from.filter((account) => {
@@ -1449,7 +1528,8 @@ export async function inventory(from, to, paths, report = () => {}, options = {}
     cloudRequested,
     cloudError: options.cloudError ?? null,
     cacheStats: cache.stats,
-    cloud: cloudPlan
+    cloud: cloudPlan,
+    inspect: options.inspect ?? (() => options.processes ?? processTable(paths.claudeApp))
   }
 }
 
@@ -1470,7 +1550,7 @@ async function rehomeOne(s, to, journal, guard) {
   if (current.cliSessionId !== s.id || !validDesktopRecord({ file: s.file, record: current })) throw new Error('source Desktop record changed identity')
   if (recordSemantic(current) !== s.recordSemantic) throw new Error('source Desktop record changed since inventory')
   if (current.forkedFromSessionId !== s.record.forkedFromSessionId) throw new Error('source Desktop lineage changed since inventory')
-  if (current.scheduledTaskId || current.notifySessionId) throw new Error('source Desktop ownership changed since inventory')
+  if (!s.taskFamily && (current.scheduledTaskId || current.notifySessionId)) throw new Error('source Desktop ownership changed since inventory')
   if (guard.taskSessions.get(s.account.taskFile).has(current.sessionId)) throw new Error('source scheduled task ownership changed since inventory')
   if (guard.taskSessions.get(to.taskFile).has(current.sessionId)) throw new Error('target scheduled task collision')
   if (ownsWorker(guard.workers, s.id, current.sessionId)) throw new Error('running worker')
@@ -1482,6 +1562,7 @@ async function rehomeOne(s, to, journal, guard) {
   const recordSha = sha(recordText)
   await journal({ strategy: 'rehome', recordSha })
   guard.check?.()
+  await guard.taskCheck?.()
   await writeNew(record, recordText, async ({ dev, ino }) => {
     guard.created.set(record, { dev, ino })
     await journal({ created: { dev, ino } })
@@ -1495,6 +1576,7 @@ async function rehomeOne(s, to, journal, guard) {
   if (sha(afterRecord) !== sourceRecordSha) throw new Error('source Desktop record changed during move')
   if (afterSidecars.fingerprint !== sourceSidecars.fingerprint) throw new Error('source sidecars changed during move')
   guard.check?.()
+  await guard.taskCheck?.()
   for (const member of s.members ?? [s]) {
     member.strategy = 'rehome'
     member.transcriptFingerprint = transcriptFingerprint
@@ -1513,10 +1595,10 @@ async function rehomeOne(s, to, journal, guard) {
     recordSha,
     recordSnapshot: placed,
     recordSemantic: recordSemantic(placed),
-    recordKeepSemantic: keepRecordSemantic(placed),
     targetRecordId: current.sessionId,
     taskFile: to.taskFile,
     taskOwned: false,
+    ...(s.taskFamily ? { taskFamily: s.taskFamily.key } : {}),
     transcriptFingerprint,
     sidecars: { count: sourceSidecars.count, bytes: sourceSidecars.bytes, fingerprint: sourceSidecars.fingerprint },
     events: s.roots.size
@@ -1540,7 +1622,8 @@ const ownership = (row, liveWorkers, bridges = true) => {
     row.worker || ownsWorker(liveWorkers, row.id, record.sessionId) ? 'running worker' : null
   ].filter(Boolean).join(', ')
 }
-const rehomeOwnership = (row, liveWorkers) => ownership(row, liveWorkers, false)
+const rehomeOwnership = (row, liveWorkers) => row.taskFamily && !row.taskFamily.error
+  ? (row.worker || ownsWorker(liveWorkers, row.id, desktopRecordOf(row).sessionId) ? 'running worker' : '') : ownership(row, liveWorkers, false)
 const retirementOwnership = (inv, row, owner, liveWorkers) => owner.history.strategy === 'rehome' || inv.cloudRequested ? rehomeOwnership(row, liveWorkers) : ownership(row, liveWorkers)
 const inventoryFailure = (item) => ({
   id: item.id ?? null,
@@ -1586,13 +1669,15 @@ async function targetChanges(row, liveWorkers, checkShared = true, allowRecordDr
   if (currentRecord) {
     try {
       const record = JSON.parse(currentRecord)
-      if (row.strategy === 'rehome' && allowRecordDrift && row.recordKeepSemantic) recordChanged = keepRecordSemantic(record) !== row.recordKeepSemantic
+      if (allowRecordDrift && row.recordSnapshot) recordChanged = !validDesktopRecord({ file: row.record, record }) ||
+        ['sessionId', 'cliSessionId', 'cwd', 'originCwd'].some(key => record[key] !== row.recordSnapshot[key]) ||
+        record.cliSessionId !== row.targetId || record.sessionId !== row.targetRecordId
       else recordChanged = !row.recordSemantic || recordSemantic(record) !== row.recordSemantic
     } catch { recordChanged = true }
   }
   if (recordChanged) changes.push('desktop record')
-  if (row.taskFile && (await taskSessions(row.taskFile)).has(row.targetRecordId ?? `local_${row.targetId}`) !== row.taskOwned) changes.push('scheduled tasks')
-  if (ownsWorker(liveWorkers, row.targetId, row.targetRecordId)) changes.push('running worker')
+  if (!allowRecordDrift && row.taskFile && (await taskSessions(row.taskFile)).has(row.targetRecordId ?? `local_${row.targetId}`) !== row.taskOwned) changes.push('scheduled tasks')
+  if (!allowRecordDrift && ownsWorker(liveWorkers, row.targetId, row.targetRecordId)) changes.push('running worker')
   return changes
 }
 
@@ -1684,6 +1769,11 @@ async function deferredWorkflow(paths) {
     const sources = [...new Map(receipt.remoteUndoing.map((row) => [`${row.account}/${row.org}`, { account: row.account, org: row.org, label: accountLabel(row) }])).values()]
     return { ...latest, mode: 'undo', sources }
   }
+  if ((receipt.pending || receipt.retiring || receipt.finalizing || receipt.undoing) && receipt.taskTransfers?.length) {
+    const transfers = receipt.undoing ? receipt.taskTransfers : receipt.taskTransfers.slice(receipt.appendCheckpoint?.taskTransfers ?? 0)
+    const sources = [...new Map(transfers.map(row => [`${row.from.account}/${row.from.org}`, row.from])).values()]
+    if (sources.length) return { ...latest, mode: receipt.undoing ? 'undo' : 'recovery', recovery: true, sources }
+  }
   if (receipt.held?.length) {
     const sources = [...new Map(receipt.held.flatMap((row) => row.sources).map((row) => [`${row.account}/${row.org}`, { account: row.account, org: row.org, label: accountLabel(row) }])).values()]
     return { ...latest, mode: 'local', sources }
@@ -1693,10 +1783,11 @@ async function deferredWorkflow(paths) {
   return sources.length ? { ...latest, mode: 'cloud', sources } : null
 }
 
-const saveText = async (file, text) => {
+const saveText = async (file, text, before = () => {}) => {
   const temp = `${file}.${process.pid}.${randomUUID()}.tmp`
   try {
     await writeFile(temp, text, { flag: 'wx', mode: 0o600 })
+    await before()
     await rename(temp, file)
     return text
   } finally {
@@ -1751,7 +1842,7 @@ async function recoveryPending(paths) {
   const latest = await latestReceipt(paths)
   if (!latest || latest.corrupt) return latest
   const { name, file, receipt } = latest
-  return receipt.pending || receipt.retiring || receipt.finalizing || receipt.undoing || receipt.remotePending || receipt.remoteUndoing?.length ? { name, file, receipt } : null
+  return needsRecovery(receipt) ? { name, file, receipt } : null
 }
 
 async function park(plan, before = async () => {}) {
@@ -1774,9 +1865,10 @@ async function park(plan, before = async () => {}) {
   }
 }
 
-async function restore(plan, root) {
+async function restore(plan, root, before = () => {}) {
   for (const p of [...plan].reverse()) {
     for (const [original, parked] of [...p.moved].reverse()) {
+      await before()
       if ((await exists(parked)) && !(await exists(original))) await rename(parked, original)
     }
   }
@@ -1808,31 +1900,113 @@ async function prepareUndo(receipt, paths) {
   return plan
 }
 
-async function finishUndo(receipt, file, paths) {
+async function taskTransferProblems(transfers, paths, inspect, partial = false, check = () => {}) {
+  const problems = []
+  for (const family of transfers ?? []) {
+    check()
+    try {
+      const table = inspect?.() ?? processTable(paths.claudeApp)
+      if (await schedulerBusy(paths, [family.from, family.to], table)) problems.push(SCHEDULER_OWNS)
+      if (sameAccount(family.from, family.to)) throw new Error('scheduled task namespaces must differ')
+      const selected = []
+      for (const [file, namespace] of [[family.sourceFile, family.from], [family.targetFile, family.to]]) {
+        if (!UUID.test(namespace.account) || !UUID.test(namespace.org) || file !== path.join(paths.records, namespace.account, namespace.org, 'scheduled-tasks.json')) throw new Error('scheduled task namespace mismatch')
+        const registry = (await taskSessions(file)).registry
+        const tasks = registry?.scheduledTasks ?? []
+        const owned = tasks.filter(task => family.ids.includes(task.id))
+        if (owned.length && stable(owned.toSorted((a, b) => a.id.localeCompare(b.id))) !== stable(family.tasks.toSorted((a, b) => a.id.localeCompare(b.id)))) throw new Error('scheduled task registrations changed')
+        if (tasks.some(task => !family.ids.includes(task.id) && family.recordIds.includes(task.notifySessionId))) throw new Error('new scheduled task dependency')
+        if (family.state) {
+          const expected = owned.length ? family.state : file === family.targetFile ? family.targetState : taskState(null, [])
+          if (stable(taskState(registry, family.ids)) !== stable(expected)) throw new Error('scheduled task state changed')
+        }
+        selected.push(owned.length > 0)
+        for (const recordFile of await recordFiles(path.dirname(file))) {
+          check()
+          const record = await readJson(recordFile)
+          if (!record || typeof record !== 'object' || Array.isArray(record)) throw new Error('unreadable scheduled task family dependency')
+          const member = family.recordIds.includes(record.sessionId)
+          if (!member && file === family.targetFile && family.links.some(link => link[1] === record.cliSessionId)) throw new Error('target scheduled task session id collision')
+          if (!member && (family.ids.includes(record.scheduledTaskId) || family.recordIds.includes(record.notifySessionId) || family.recordIds.includes(record.forkedFromSessionId))) throw new Error('new scheduled task family dependency')
+          if (member && (!validDesktopRecord({ file: recordFile, record }) || !family.links.some(link => stable(link) === stable(taskLinks(record))))) throw new Error('scheduled task family identity or route changed')
+          if (table.some(worker => worker.worker && ownsWorker(new Set(worker.ids), record.cliSessionId, record.sessionId)) && member) throw new Error('running worker owns scheduled task family')
+        }
+      }
+      if (family.tasks.length && (selected.every(Boolean) || !partial && (selected[0] || !selected[1]))) throw new Error('scheduled task ownership changed')
+    } catch (error) { problems.push(error.message) }
+  }
+  return [...new Set(problems)]
+}
+
+async function writeTaskRegistrations(transfers, side, present, paths, inspect, check = () => {}) {
+  for (const family of transfers ?? []) {
+    check(true)
+    const problems = await taskTransferProblems([family], paths, inspect, true, check)
+    if (problems.length) throw new Error(problems.join(', '))
+    const file = side === 'source' ? family.sourceFile : family.targetFile
+    const registry = (await taskSessions(file)).registry
+    const tasks = registry?.scheduledTasks ?? []
+    const owned = tasks.filter(task => family.ids.includes(task.id))
+    if (Boolean(owned.length) === present || !family.tasks.length) continue
+    const next = tasks.filter(task => !family.ids.includes(task.id))
+    if (present) {
+      for (const task of family.tasks) {
+        const order = family.sourceOrder
+        const following = side === 'source' ? next.findIndex(row => order.indexOf(row.id) > order.indexOf(task.id)) : -1
+        next.splice(following < 0 ? next.length : following, 0, task)
+      }
+    }
+    if (stable((await taskSessions(file)).registry) !== stable(registry)) throw new Error('scheduled task registry changed before write')
+    check(true)
+    if (await schedulerBusy(paths, [family.from, family.to], inspect?.())) throw new Error(SCHEDULER_OWNS)
+    const after = { ...registry, scheduledTasks: next }
+    if (family.state) for (const key of TASK_STATE_KEYS) {
+      const selected = present ? family.state[key] : side === 'target' ? family.targetState[key] : {}
+      const entries = { ...Object.fromEntries(Object.entries(registry?.[key] ?? {}).filter(([id]) => !family.ids.includes(id))), ...selected }
+      if (Object.hasOwn(registry ?? {}, key) || Object.keys(entries).length) after[key] = entries
+      if (!present && side === 'target' && !family.targetStateFields.includes(key) && !Object.keys(entries).length) delete after[key]
+    }
+    if (!present && side === 'target' && !family.targetHadTasks && !next.length) delete after.scheduledTasks
+    const remove = !present && side === 'target' && !family.targetExisted && !Object.keys(after).length
+    if (remove) await unlink(file)
+    else await saveText(file, jsonText(after), async () => {
+      check(true)
+      if (stable((await taskSessions(file)).registry) !== stable(registry)) throw new Error('scheduled task registry changed before publication')
+      if (await schedulerBusy(paths, [family.from, family.to], inspect?.())) throw new Error(SCHEDULER_OWNS)
+    })
+    if (stable((await taskSessions(file)).registry) !== stable(remove ? null : after)) throw new Error('scheduled task registry changed during write')
+  }
+}
+
+async function finishUndo(receipt, file, paths, options = {}) {
   const root = path.join(paths.state, 'quarantine')
   const dest = path.join(root, receipt.at)
   const superseded = receipt.superseded ?? [], undoing = receipt.undoing ?? []
   const problems = [
     ...await restoreProblems(superseded, root),
     ...await restoreProblems(undoing, root),
-    ...await activationProblems(receipt)
+    ...await activationProblems(receipt),
+    ...await taskTransferProblems(receipt.taskTransfers, paths, options.inspect ?? options.io?.inspect ?? (() => options.processes ?? processTable(paths.claudeApp)), true, options.check)
   ]
   if (await exists(path.join(dest, 'receipt.json'))) problems.push('undo receipt path occupied')
   const liveWorkers = workers()
   for (const row of receipt.sessions) {
     if (ownsWorker(liveWorkers, row.targetId, row.targetRecordId)) problems.push(`${row.title} | running worker kept in destination`)
-    if (row.taskFile && (await taskSessions(row.taskFile)).has(row.targetRecordId ?? `local_${row.targetId}`) !== row.taskOwned) problems.push(`${row.title} | scheduled tasks changed`)
+    if (!row.taskFamily && row.taskFile && (await taskSessions(row.taskFile)).has(row.targetRecordId ?? `local_${row.targetId}`) !== row.taskOwned) problems.push(`${row.title} | scheduled tasks changed`)
   }
   problems.push(...await undoParentProblems(receipt))
   if (problems.length) return { receipt, restoreProblems: problems }
   let failure
+  const inspect = options.inspect ?? options.io?.inspect ?? (() => options.processes ?? processTable(paths.claudeApp))
   try {
-    await restore(superseded, root)
-    await park(undoing)
+    await writeTaskRegistrations(receipt.taskTransfers, 'target', false, paths, inspect, options.check)
+    await restore(superseded, root, options.check)
+    await park(undoing, async () => options.check?.())
     await restoreActivations(receipt)
+    await writeTaskRegistrations(receipt.taskTransfers, 'source', true, paths, inspect, options.check)
     await mkdir(dest, { recursive: true })
   } catch (error) { failure = error }
-  problems.push(...await undoParentProblems(receipt))
+  problems.push(...await undoParentProblems(receipt), ...await taskTransferProblems(receipt.taskTransfers, paths, inspect, true, options.check))
   if (!problems.length && failure) throw failure
   if (problems.length) {
     if (failure) problems.push(failure.message)
@@ -1940,12 +2114,16 @@ async function reconcile(paths, options = {}) {
 async function reconcileFiles(paths, options = {}) {
   const p = await recoveryPending(paths)
   if (!p) return null
+  if (options.receiptFile && p.file !== options.receiptFile) return { title: 'recovery blocked', error: 'The operation receipt changed' }
   if (p.corrupt) {
     await rename(p.file, `${p.file}.corrupt`)
     return { title: p.name, error: 'corrupt receipt set aside' }
   }
   const { receipt } = p
+  const inspect = options.inspect ?? options.io?.inspect ?? (() => options.processes ?? processTable(paths.claudeApp))
   const checkpoint = receipt.appendCheckpoint
+  const taskProblems = await taskTransferProblems(receipt.undoing ? receipt.taskTransfers : (receipt.taskTransfers ?? []).slice(checkpoint?.taskTransfers ?? 0), paths, inspect, true, options.check)
+  if (taskProblems.length && !(receipt.undoing && receipt.remoteUndoing?.length && taskProblems.every(problem => problem === SCHEDULER_OWNS) && !options.check)) return { title: 'scheduled task recovery blocked', error: taskProblems.join(', '), problems: taskProblems }
   if (checkpoint && (!Number.isSafeInteger(checkpoint.sessions) || checkpoint.sessions < 0 || checkpoint.sessions > (receipt.sessions?.length ?? 0) || !Number.isSafeInteger(checkpoint.superseded) || checkpoint.superseded < 0 || checkpoint.superseded > (receipt.superseded?.length ?? 0) || !Array.isArray(checkpoint.held))) return { title: 'recovery blocked', error: 'invalid append checkpoint' }
   receipt.failed ??= []
   receipt.superseded ??= []
@@ -1955,7 +2133,7 @@ async function reconcileFiles(paths, options = {}) {
     const remote = await restoreRemote(receipt, p.file, paths, options.cloud)
     if (remote.problems.length) return { title: 'Remote Control undo recovery blocked', error: remote.problems.join(', '), problems: remote.problems }
     if (remote.pending.length) return { title: 'Undo pending', error: `sign Claude Desktop into ${remote.pending.join(' or ')}`, pendingUndo: remote.pending, remoteRestored: remote.restored, receipt }
-    const result = await finishUndo(receipt, p.file, paths)
+    const result = await finishUndo(receipt, p.file, paths, options)
     if (result.restoreProblems) return { title: 'undo recovery blocked', error: result.restoreProblems.join(', '), problems: result.restoreProblems }
     return { title: `${receipt.sessions.length} sessions`, error: 'interrupted undo completed', undo: result }
   }
@@ -1992,7 +2170,7 @@ async function reconcileFiles(paths, options = {}) {
     if (blocked.length) return { title: 'retirement recovery blocked', error: blocked.join(', '), problems: blocked }
     await restore(plan, root)
     receipt.retiring = null
-    if (!receipt.appendCheckpoint) {
+    if (!receipt.appendCheckpoint && !receipt.taskTransfers?.length) {
       receipt.finalizing = false
       cancelCloudChecks(receipt)
       await saveJson(p.file, receipt)
@@ -2008,6 +2186,7 @@ async function reconcileFiles(paths, options = {}) {
     const used = strategy === 'rehome'
       ? await readFile(made[0]).then((raw) => Boolean(receipt.pending.recordSha && sha(raw) !== receipt.pending.recordSha), () => false)
       : await changed(made[0], targetId, knownOf(receipt.pending))
+    if ((used || foreign) && receipt.taskTransfers?.some(family => family.recordIds.includes(path.basename(made[0], '.json')))) return { title: 'scheduled task recovery blocked', error: 'scheduled task target record changed, recovery remains pending' }
     if (!used && !foreign) await quarantine(made, path.join(paths.state, 'quarantine', receipt.at, 'failed'))
     const changedCopy = strategy === 'rehome' ? 'target record' : 'remote rescue'
     const error = foreign ? 'interrupted, independently created target left in place' : used ? `interrupted, ${changedCopy} changed since, left in place` : 'interrupted'
@@ -2020,15 +2199,18 @@ async function reconcileFiles(paths, options = {}) {
     const checkpoint = receipt.appendCheckpoint
     const root = path.join(paths.state, 'quarantine')
     const superseded = receipt.superseded.slice(checkpoint?.superseded ?? 0)
+    const taskTransfers = (receipt.taskTransfers ?? []).slice(checkpoint?.taskTransfers ?? 0)
     const blocked = await restoreProblems(superseded, root)
     if (blocked.length) return { title: 'recovery blocked', error: blocked.join(', '), problems: blocked }
-    await restore(superseded, root)
+    await writeTaskRegistrations(taskTransfers, 'target', false, paths, inspect, options.check)
+    await restore(superseded, root, options.check)
     const kept = []
     let rolledBack = 0
     const dest = path.join(paths.state, 'quarantine', receipt.at, 'failed')
     const liveWorkers = workers()
     for (const row of (receipt.sessions ?? []).slice(checkpoint?.sessions ?? 0)) {
-      const changes = await rollbackTarget(row, dest, liveWorkers)
+      options.check?.()
+      const changes = await rollbackTarget(row.taskFamily ? { ...row, taskOwned: false } : row, dest, liveWorkers)
       if (changes.length) {
         kept.push(row)
         receipt.failed.push({ id: row.id, title: row.title, error: `interrupted finalization, ${changes.join(', ')} changed since, left in place` })
@@ -2037,6 +2219,9 @@ async function reconcileFiles(paths, options = {}) {
         rolledBack++
       }
     }
+    if (kept.some(row => row.taskFamily)) return { title: 'scheduled task recovery blocked', error: 'scheduled task family records changed, recovery remains pending' }
+    await writeTaskRegistrations(taskTransfers, 'source', true, paths, inspect, options.check)
+    receipt.taskTransfers = (receipt.taskTransfers ?? []).slice(0, checkpoint?.taskTransfers ?? 0)
     receipt.sessions = [...(receipt.sessions ?? []).slice(0, checkpoint?.sessions ?? 0), ...kept]
     receipt.superseded = receipt.superseded.slice(0, checkpoint?.superseded ?? 0)
     receipt.finalizing = false
@@ -2497,7 +2682,6 @@ async function applyActivation(activation, row) {
   row.recordSha = activation.afterSha
   row.recordSnapshot = structuredClone(activation.after)
   row.recordSemantic = activation.afterSemantic
-  row.recordKeepSemantic = keepRecordSemantic(activation.after)
   row.archived = false
   if (row.session) {
     row.session.record = activation.after
@@ -2547,7 +2731,6 @@ async function rollbackActivation(activation, row = null) {
     row.recordSha = sha(text)
     row.recordSnapshot = structuredClone(restored)
     row.recordSemantic = recordSemantic(restored)
-    row.recordKeepSemantic = keepRecordSemantic(restored)
     row.archived = true
     if (row.session) {
       row.session.record = restored
@@ -2564,8 +2747,9 @@ function clearCloudAttempt(receipt, cloud) {
   receipt.failed = (receipt.failed ?? []).filter((failure) => !cloudTagged(failure, cloud))
   receipt.cloudError = null
   if (receipt.verification) {
+    const retried = (receipt.verification.problems ?? []).some(problem => cloudTagged(problem, cloud))
     receipt.verification.problems = (receipt.verification.problems ?? []).filter((problem) => !cloudTagged(problem, cloud))
-    receipt.verification.ok = receipt.verification.problems.length === 0
+    receipt.verification.ok = receipt.verification.problems.length === 0 && (receipt.verification.ok !== false || retried)
   }
   const check = receiptCloudCheck(receipt, cloud)
   if (check) {
@@ -2751,6 +2935,87 @@ async function restoreRemote(receipt, file, paths, supplied) {
 }
 
 async function transfer(inv, to, paths, report, context = {}) {
+  const families = [...new Set(inv.move.map(row => row.taskFamily).filter(Boolean))]
+  if (!families.length) return transferRecords(inv, to, paths, report, context)
+  const firstCount = context.existing?.receipt.sessions.length ?? 0
+  const firstSuperseded = context.existing?.receipt.superseded.length ?? 0
+  context = { ...context, at: context.existing?.receipt.at ?? context.at ?? stamp() }
+  const file = context.existing?.file ?? path.join(paths.state, `${context.at}.json`)
+  const emptyCloud = { checked: false, matches: [], blocked: [], waiting: [], later: [] }
+  const held = [...(inv.held ?? []), ...families.map(family => {
+    const members = inv.sources.filter(row => row.taskFamily === family), row = members[0]
+    return { id: row.id, record: row.file, recordId: row.record.sessionId, title: row.title, ...family.from, workers: [],
+      sources: members.map(member => ({ id: member.id, file: member.file, ...family.from })) }
+  })]
+  const regular = { ...inv, held, cloud: emptyCloud, move: inv.move.filter(row => !row.taskFamily), sources: inv.sources.filter(row => !row.taskFamily) }
+  const total = inv.move.length + (inv.cloud?.matches.filter(match => match.target.kind === 'rescue').length ?? 0)
+  const totals = { move: total, verify: total, retire: regular.sources.length + families.reduce((n, family) => n + family.files.length, 0) }
+  const completed = { move: 0, verify: 0, retire: 0 }, details = new Map()
+  const unitReport = (final = false) => {
+    const before = { ...completed }
+    return (stage, text, extra) => {
+      if (!extra?.live) { details.set(stage, text); return }
+      const phase = stage === 'rescue' ? 'move' : stage
+      if (Object.hasOwn(totals, phase)) {
+        if (extra.total > 0) completed[phase] = before[phase] + extra.completed
+        if (extra.completed !== undefined && (phase === 'move' ? extra.total > 0 : final)) progress(report, phase, completed[phase], totals[phase])
+      } else if (final) report(stage, text, extra)
+    }
+  }
+  let result = await transferRecords(regular, to, paths, unitReport(), context)
+  if (result?.deferred) return result
+  for (const family of families) {
+    context.check?.(true)
+    const unit = { ...inv, move: inv.move.filter(row => row.taskFamily === family), sources: inv.sources.filter(row => row.taskFamily === family),
+      there: [], blocked: [], unreadable: [], rejected: [], cloud: emptyCloud, cloudRequested: false }
+    const existing = result?.file ? { file: result.file, receipt: result.receipt } : context.existing
+    unit.held = (existing?.receipt.held ?? held).filter(row => !row.sources.some(source => family.files.includes(source.file)))
+    if (!existing) Object.assign(unit, { blocked: inv.blocked, unreadable: inv.unreadable, rejected: inv.rejected })
+    try {
+      result = await transferRecords(unit, to, paths, unitReport(), { ...context, existing, taskFamily: family })
+    } catch (error) {
+      const receipt = await readReceipt(file).catch(error => { if (error.code !== 'ENOENT') throw error; return null })
+      if (!receipt || !receipt.finalizing) {
+        if (!receipt) return { receipt: { failed: [{ title: 'Scheduled task family', error: error.message }], sessions: [], superseded: [], verification: { ok: true, problems: [] } }, file: null, ok: false, validationOnly: true }
+        receipt.failed.push({ id: null, title: 'Scheduled task family', error: error.message })
+        await saveJson(file, receipt)
+        result = { file, receipt, ok: false }
+        continue
+      }
+      context.check?.(true)
+      const recovered = await reconcileFiles(paths, { receiptFile: file, inspect: inv.inspect, check: context.check })
+      const after = await readReceipt(file)
+      if (needsRecovery(after)) return { file, receipt: after, reconciled: recovered, recoveryRequired: true, ok: false }
+      after.failed.push({ id: null, title: 'Scheduled task family', error: error.message })
+      await saveJson(file, after)
+      result = { file, receipt: after, ok: false }
+    }
+  }
+  const cloud = { ...inv.cloud, matches: (inv.cloud?.matches ?? []).map(match => {
+    const base = match.target.kind === 'rescue' && match.target.base
+    if (base?.kind !== 'move' || !result.receipt.superseded.some(row => row.source && row.moved.some(([file]) => file === base.row.file))) return match
+    const placed = result.receipt.sessions.find(row => row.id === base.id && row.record === path.join(to.dir, path.basename(base.row.file)))
+    if (!placed) return match
+    return { ...match, target: { ...match.target, base: { ...base, kind: 'existing', row: { ...base.row, file: placed.record, record: placed.recordSnapshot,
+      recordSemantic: placed.recordSemantic, recordSha: placed.recordSha, account: to, taskOwned: placed.taskOwned } } } }
+  }) }
+  result = await transferRecords({ ...inv, cloud, move: [], sources: [], targets: [], there: [], blocked: [], unreadable: [], rejected: [], held: result.receipt.held },
+    to, paths, unitReport(true), { ...context, existing: { file, receipt: result.receipt }, wholeOperation: true })
+  for (const [stage, text] of details) report(stage, text)
+  const receipt = result.receipt
+  if (inv.cloudRequested && !context.existing) {
+    const current = await accounts(paths)
+    receipt.cloudChecks = receipt.cloudChecks.filter(check => inv.cloud?.checked && sameAccount(check, inv.cloud) ||
+      inv.deferredCloudSources?.some(source => sameAccount(check, source)) || localCloudPending(current.find(account => sameAccount(account, check))))
+    await saveJson(result.file, receipt)
+  }
+  const pendingCloud = openCloudChecks(receipt).length
+  return { ...result, ok: receiptOkay(receipt), complete: !pendingCloud && !receipt.held?.length, pendingCloud,
+    pendingLabels: cloudCheckLabels(receipt), held: receipt.held, added: receipt.sessions.length - firstCount,
+    targetChanged: receipt.sessions.length > firstCount || receipt.superseded.slice(firstSuperseded).some(row => !row.source), problems: receipt.verification?.problems ?? [] }
+}
+
+async function transferRecords(inv, to, paths, report, context = {}) {
   context.check?.(true)
   if (context.restart && inv.cloud?.checked) throw new Error('Cloud work cannot run inside the restart window')
   const deferred = await deferredWorkflow(paths)
@@ -2760,7 +3025,7 @@ async function transfer(inv, to, paths, report, context = {}) {
   const at = context.existing?.receipt.at ?? context.at ?? stamp()
   const held = inv.held ?? []
   const heldIds = new Set(held.flatMap((row) => [row.id, ...row.sources.map((source) => source.id)]))
-  const initialFailures = inventoryFailures(inv).filter((row) => !(heldIds.has(row.id) && [WORKER_OWNS, PARENT_MISSING].includes(row.error)))
+  const initialFailures = inventoryFailures(inv).filter((row) => !(heldIds.has(row.id) && [WORKER_OWNS, PARENT_MISSING, SCHEDULER_OWNS].includes(row.error)))
   const receipt = context.existing?.receipt ?? {
     at,
     startedAt,
@@ -2783,7 +3048,7 @@ async function transfer(inv, to, paths, report, context = {}) {
   }
   const file = path.join(paths.state, `${at}.json`)
   if (context.existing) {
-    receipt.appendCheckpoint = { sessions: receipt.sessions.length, superseded: receipt.superseded.length, verification: receipt.verification, held: receipt.held }
+    receipt.appendCheckpoint = { sessions: receipt.sessions.length, superseded: receipt.superseded.length, taskTransfers: receipt.taskTransfers?.length ?? 0, verification: receipt.verification, held: receipt.held }
     const retryIds = new Set([...inv.move, ...inv.there].flatMap((row) => (row.members ?? [row]).map((member) => member.id)))
     receipt.failed = receipt.failed.filter((row) => !retryIds.has(row.id) || row.retained || row.cloudAccount)
     receipt.failed.push(...initialFailures)
@@ -2797,8 +3062,28 @@ async function transfer(inv, to, paths, report, context = {}) {
   const previousCount = receipt.sessions.length
   const previousSuperseded = receipt.superseded.length
   const save = () => saveJson(file, receipt)
-  let events = 0
+  const family = context.taskFamily
+  if (family) {
+    const source = (await taskSessions(family.sourceFile)).registry
+    const target = (await taskSessions(family.targetFile)).registry
+    const tasks = (source?.scheduledTasks ?? []).filter(task => family.ids.includes(task.id))
+    if (stable(tasks.map(task => [task.id, task.notifySessionId ?? null]).sort()) !== stable(family.routes.toSorted())) throw new Error('scheduled task family changed since inventory')
+    const state = taskState(source, family.ids), targetState = taskState(target, family.ids)
+    if (taskStateConflict(state, targetState)) throw new Error('target scheduled task state collision')
+    const transfer = { ...family, tasks, state, targetState, targetStateFields: TASK_STATE_KEYS.filter(key => Object.hasOwn(target ?? {}, key)),
+      sourceOrder: (source?.scheduledTasks ?? []).map(task => task.id), targetExisted: target !== null, targetHadTasks: Object.hasOwn(target ?? {}, 'scheduledTasks') }
+    const problems = await taskTransferProblems([transfer], paths, inv.inspect, true, context.check)
+    if (problems.length) throw new Error(problems.join(', '))
+    receipt.taskTransfers = [...(receipt.taskTransfers ?? []), transfer]
+    await save()
+    await writeTaskRegistrations([transfer], 'source', false, paths, inv.inspect, context.check)
+    for (const row of inv.sources) row.taskOwned = false
+  }
   const rehomeGuard = { workers: workers(), taskSessions: new Map(), created: new Map(), check: context.check }
+  if (family) rehomeGuard.taskCheck = async () => {
+    const problems = await taskTransferProblems(receipt.taskTransfers.filter(row => row.key === family.key), paths, inv.inspect, true, context.check)
+    if (problems.length) throw new Error(problems.join(', '))
+  }
   for (const file of new Set([...inv.move.map((row) => row.account.taskFile), to.taskFile])) {
     rehomeGuard.taskSessions.set(file, await taskSessions(file))
   }
@@ -2817,7 +3102,6 @@ async function transfer(inv, to, paths, report, context = {}) {
         const row = await rehomeOne(s, to, async (patch) => { Object.assign(receipt.pending, patch); await journal.save() }, rehomeGuard)
         receipt.sessions.push(row)
         if (row.targetRecordId) landedRecordIds.add(row.targetRecordId)
-        events += row.events
       } catch (error) {
         if (error.code === 'JOURNAL_WRITE') throw error
         const raw = await readFile(made[0]).catch(() => null)
@@ -2839,7 +3123,6 @@ async function transfer(inv, to, paths, report, context = {}) {
   context.check?.(true)
   const rescues = inv.cloud?.matches.filter((match) => match.target.kind === 'rescue') ?? []
   const rescued = await rescueCloud(inv, receipt, to, paths, save, report)
-  events += rescued.events
   const done = receipt.sessions.length
   const { ok, lines, problems } = await verify(receipt.sessions.slice(previousCount), report, context.check)
   const rescueIds = new Set(rescued.rows.map((row) => row.targetId))
@@ -2848,6 +3131,15 @@ async function transfer(inv, to, paths, report, context = {}) {
   receipt.verification = { ok: ok && receipt.appendCheckpoint?.verification?.ok !== false && !priorProblems.length, problems: [...priorProblems, ...recordedProblems] }
   await save()
   await retire(inv, to, receipt, paths, at, problems, save, report, context.check)
+  if (family) {
+    if (!ok || inv.sources.some(source => !receipt.superseded.some(row => row.source && row.moved.some(([file]) => file === source.file)))) throw new Error('scheduled task family did not move completely')
+    const transfers = receipt.taskTransfers.filter(row => row.key === family.key)
+    await writeTaskRegistrations(transfers, 'target', true, paths, inv.inspect, context.check)
+    const tasks = transfers[0].tasks
+    for (const row of receipt.sessions.filter(row => row.taskFamily === family.key)) row.taskOwned = tasks.some(task => task.notifySessionId === row.targetRecordId)
+    const taskProblems = await taskTransferProblems(transfers, paths, inv.inspect, false, context.check)
+    if (taskProblems.length) throw new Error(taskProblems.join(', '))
+  }
   if (inv.cloudRequested) {
     const current = await accounts(paths)
     const actual = receipt.fromAccounts.filter((source) => localCloudPending(current.find((account) => sameAccount(account, source))))
@@ -2858,14 +3150,14 @@ async function transfer(inv, to, paths, report, context = {}) {
   receipt.finalizing = false
   delete receipt.appendCheckpoint
   delete receipt.automaticCloudAttempt
-  receipt.failed = receipt.failed.filter((row) => !(heldIds.has(row.id) && [WORKER_OWNS, PARENT_MISSING].includes(row.error)))
+  receipt.failed = receipt.failed.filter((row) => !(heldIds.has(row.id) && [WORKER_OWNS, PARENT_MISSING, SCHEDULER_OWNS].includes(row.error)))
   await save()
-  if (inv.move.length || rescues.length) {
+  if (inv.move.length || rescues.length || context.wholeOperation) {
     const rehomed = receipt.sessions.filter((row) => row.strategy === 'rehome').length
     const rescuedCount = receipt.sessions.filter((row) => row.strategy === 'remote').length
     report('move', [
       `${count(done)} ${receipt.verification.ok ? '✓' : 'need verification'}`,
-      `${count(events)} events`,
+      `${count(receipt.sessions.reduce((n, row) => n + row.events, 0))} events`,
       rehomed ? `${count(rehomed)} zero-copy` : null,
       rescuedCount ? `${count(rescuedCount)} rescued` : null,
       receipt.failed.length ? `${receipt.failed.length} failed` : null
@@ -2905,7 +3197,7 @@ export function finishPending(paths, options = {}) {
   return locked(paths, async () => {
     const recovery = await recoveryPending(paths)
     if (recovery) {
-      const reconciled = await reconcile(paths, { cloud: options.cloud })
+      const reconciled = await reconcile(paths, options)
       if (reconciled?.undo) return { ...reconciled.undo, ok: true, complete: true, pendingCloud: 0, pendingUndo: [] }
       if (reconciled?.pendingUndo) return { receipt: reconciled.receipt, ok: true, complete: false, pendingCloud: 0, pendingUndo: reconciled.pendingUndo, remoteRestored: reconciled.remoteRestored ?? 0 }
       return { reconciled, recoveryRequired: true, ok: false, complete: false }
@@ -2916,8 +3208,11 @@ export function finishPending(paths, options = {}) {
     if (options.receiptFile && file !== options.receiptFile) return { nothing: true, ok: true }
     const outstanding = openCloudChecks(receipt)
     if (!outstanding.length) {
-      const ok = receipt.verification?.ok !== false && !receipt.verification?.problems?.length
-      return { nothing: ok, receipt, file, ok, complete: true, pendingCloud: 0, failed: receipt.failed ?? [], problems: receipt.verification?.problems ?? [] }
+      const ok = finishOkay(receipt), complete = !receipt.held?.length && !legacyLocalFailures(receipt).length
+      const nothing = ok && complete
+      return { nothing, receipt, file, ok, complete, pendingCloud: 0, failed: (receipt.failed ?? []).filter(row => nothing || row.cloudAccount),
+        notMoved: nothing ? [] : (receipt.failed ?? []).filter(row => !row.cloudAccount), problems: receipt.verification?.problems ?? [],
+        reason: receipt.verification?.ok === false && !receipt.verification.problems?.length ? 'The previous move failed verification' : undefined }
     }
     if (options.automatic) {
       const key = `${options.automatic.account}/${options.automatic.org}`
@@ -2968,13 +3263,13 @@ export function finishPending(paths, options = {}) {
     await save()
     const completedRemote = receipt.remote.slice(beforeRemote)
     const pendingCloud = openCloudChecks(receipt).length
-    const failed = receipt.failed.filter((failure) => cloudTagged(failure, cloud))
-    const ok = receiptOkay(receipt)
+    const failed = receipt.failed.filter(failure => failure.cloudAccount)
+    const ok = finishOkay(receipt)
     return {
       file,
       receipt,
       ok,
-      complete: pendingCloud === 0,
+      complete: pendingCloud === 0 && !receipt.held?.length && !legacyLocalFailures(receipt).length,
       pendingCloud,
       pendingLabels: cloudCheckLabels(receipt),
       rescued: rescued.rows.length,
@@ -2983,7 +3278,9 @@ export function finishPending(paths, options = {}) {
       checkedAccount: accountRef(check),
       newerCloud: inv.cloud.later.length,
       failed,
+      notMoved: receipt.failed.filter(failure => !failure.cloudAccount),
       problems: receipt.verification.problems,
+      reason: receipt.verification.ok === false && !receipt.verification.problems.length ? 'The previous move failed verification' : undefined,
       checks: verification.lines,
       restart: rescued.rows.length > 0 || completedRemote.length > 0
     }
@@ -3050,14 +3347,7 @@ export function keepLocal(paths) {
     const { file, receipt } = latest
     const checks = openCloudChecks(receipt)
     const heldCancelled = (receipt.held?.length ?? 0) + legacyLocalFailures(receipt).length
-    if (!checks.length) {
-      if (!heldCancelled) return { nothing: true, file, receipt }
-      receipt.held = []
-      receipt.localCancelledAt = new Date().toISOString()
-      receipt.failed = receipt.failed.filter(row => row.error !== WORKER_OWNS)
-      await saveJson(file, receipt)
-      return { file, receipt, cancelled: 0, heldCancelled, labels: [], ok: receiptOkay(receipt), complete: true }
-    }
+    if (!checks.length && !heldCancelled) return { nothing: true, file, receipt }
     const unsafe = (receipt.verification?.problems ?? []).filter((problem) => checks.some((check) => cloudTagged(problem, check)))
     const refused = unsafe.map(problemText)
     const liveWorkers = workers()
@@ -3093,7 +3383,8 @@ export function keepLocal(paths) {
     receipt.failed = (receipt.failed ?? []).filter(row => row.error !== WORKER_OWNS).filter((failure) => !checks.some((check) => cloudTagged(failure, check)))
     receipt.cloudError = null
     await saveJson(file, receipt)
-    return { file, receipt, cancelled: checks.length, heldCancelled, labels: checks.map((check) => check.label), ok: receiptOkay(receipt), complete: true }
+    return { file, receipt, cancelled: checks.length, heldCancelled, labels: checks.map((check) => check.label), ok: finishOkay(receipt), complete: true,
+      failed: receipt.failed.filter(row => row.cloudAccount), notMoved: receipt.failed.filter(row => !row.cloudAccount) }
   })
 }
 
@@ -3108,7 +3399,13 @@ export function executeMove(from, to, paths, options = {}) {
   const now = options.io?.now ?? (() => performance.now())
   const approvedAt = options.approve ? options.approvalStartedAt ?? now() : null
   return locked(paths, async () => {
-    const reconciled = await reconcile(paths, options)
+    const recovery = options.recover ? await recoveryPending(paths) : null
+    if (options.recover && (!recovery?.receipt?.taskTransfers?.length || recovery.file !== options.receiptFile || recovery.receipt.remotePending || recovery.receipt.remoteUndoing?.length)) return { ok: false, reason: 'Task recovery changed or still needs cloud restoration' }
+    if (recovery) {
+      const problems = (await taskTransferProblems(recovery.receipt.taskTransfers, paths, options.io?.inspect ?? (() => options.processes ?? processTable(paths.claudeApp)), true)).filter(problem => problem !== SCHEDULER_OWNS)
+      if (problems.length) return { ok: false, reason: problems.join(', ') }
+    }
+    const reconciled = options.recover ? null : await reconcile(paths, options)
     if (reconciled) return { reconciled, recoveryRequired: true, ok: false }
     const deferred = await deferredWorkflow(paths)
     if (options.resume && (deferred?.mode !== 'local' || deferred.file !== options.resumeFile)) return { ok: false, reason: 'The pending move changed. No stale continuation was run.' }
@@ -3118,7 +3415,7 @@ export function executeMove(from, to, paths, options = {}) {
     if (drift.changed.length) report('changed', `${quantity(drift.changed.length, 'moved session')} now has different metadata. Evidence saved with the receipt.`)
     if (options.finish && deferred?.file !== options.receiptFile) return { ok: false, reason: 'The pending move changed before its restart' }
     const receiptFile = existing?.file ?? options.receiptFile ?? null
-    const kind = from ? 'move' : options.finish ? 'finish' : 'refresh'
+    const kind = options.recover ? 'recover' : options.undo ? 'undo' : from ? 'move' : options.finish ? 'finish' : 'refresh'
     const planFile = path.join(paths.state, 'restart-plan.json')
     const saved = options.approve ? await readJson(planFile).catch(() => null) : null
     if (options.approve && (!saved || saved.token !== options.approve || sha(stable(without(saved, ['token']))) !== saved.token || saved.kind !== kind)) {
@@ -3144,7 +3441,7 @@ export function executeMove(from, to, paths, options = {}) {
       })
       const target = latest.find((account) => sameAccount(account, chosen.to))
       if (!target) throw new Error('Destination account is no longer available')
-      const inv = await inventory(sources, target, paths, report, { cloud, cloudRequested: options.cloudRequested, cloudError: options.cloudError, requestedAt, writeCache: true, processes: inspect(), check })
+      const inv = await inventory(sources, target, paths, report, { cloud, cloudRequested: options.cloudRequested, cloudError: options.cloudError, requestedAt, writeCache: true, processes: inspect(), inspect, check })
       return { inv, target }
     }
     const initial = chosen && !saved ? await replan(existing ? null : options.cloud) : null
@@ -3164,6 +3461,14 @@ export function executeMove(from, to, paths, options = {}) {
       const budget = (options.io?.budget ?? RESTART_BUDGET) - (now() - approvedAt)
       if (budget <= (options.io?.reserve ?? REOPEN_RESERVE)) return { ok: false, reason: 'Restart planning used its mutation budget. No shutdown or held move was started.' }
       const restarted = await withDesktopRestart(plan, paths, async (context) => {
+        if (options.recover) {
+          const reconciled = await reconcileFiles(paths, { ...options, inspect, check: context.check })
+          return reconciled?.undo ? { ...reconciled.undo, ok: true, complete: true } : { reconciled, recoveryRequired: true, ok: false }
+        }
+        if (options.undo) {
+          const result = await undoFiles(paths, { ...options, inspect, check: context.check })
+          return { ...result, ok: Boolean(result.dest), complete: Boolean(result.dest) }
+        }
         if (!chosen) return null
         const { inv, target } = await replan(null, context.check)
         context.check()
@@ -3174,6 +3479,8 @@ export function executeMove(from, to, paths, options = {}) {
       return { ...(restarted.result ?? {}), ok: restarted.ok && restarted.result?.ok !== false,
         restartOutcome: restarted.restart, restarted: restarted.restart.outcome === 'reopened', reason: restarted.error }
     }
+    if (!chosen && options.recover) return { reconciled: await reconcileFiles(paths, { ...options, inspect }), recoveryRequired: true, ok: false }
+    if (!chosen && options.undo) return undoFiles(paths, { ...options, inspect })
     if (!chosen) return inspect().filter((row) => desktopExecutable(row.executable)).length > 1
       ? { ok: false, reason: 'More than one Claude Desktop instance is running. Close the extra instance before restarting.' }
       : { nothing: true, ok: true }
@@ -3205,7 +3512,15 @@ export async function finishHeld(paths, options = {}) {
   if (!to) throw new Error('Destination account is no longer available')
   const found = new Set(from.flatMap((account) => [...account.sessions, ...account.unreadable].map(desktopFileOf)))
   if ([...files].some((file) => !found.has(file))) return { ok: false, reason: 'A held source record disappeared. Its move was not marked complete.' }
-  return executeMove(from, to, paths, { ...options, resume: true, resumeFile: latest.file, cloudRequested: latest.receipt.cloudChecks.length > 0 })
+  const prior = [...latest.receipt.failed], retryIds = new Set(latest.receipt.held.flatMap(row => row.sources.map(source => source.id)))
+  const result = await executeMove(from, to, paths, { ...options, resume: true, resumeFile: latest.file, cloudRequested: latest.receipt.cloudChecks.length > 0 })
+  if (!result.receipt || result.plan || result.recoveryRequired || result.reason) return result
+  const failed = result.receipt.failed.filter(row => {
+    const at = prior.findIndex(old => stable(old) === stable(row))
+    if (at >= 0) prior.splice(at, 1)
+    return row.cloudAccount || retryIds.has(row.id) || at < 0
+  })
+  return { ...result, ok: finishOkay(result.receipt) && !failed.length, failed, notMoved: result.receipt.failed.filter(row => !failed.includes(row)) }
 }
 
 async function completeActiveCloud(result, paths, options = {}) {
@@ -3222,7 +3537,14 @@ async function completeActiveCloud(result, paths, options = {}) {
 }
 
 export async function finishWorkflow(paths, options = {}) {
-  if (await recoveryPending(paths)) return finishPending(paths, options)
+  const recovery = await recoveryPending(paths)
+  if (recovery) {
+    if (!options.background && recovery.receipt?.taskTransfers?.length && !recovery.receipt.remotePending && !recovery.receipt.remoteUndoing?.length &&
+      (options.approve || await schedulerBusy(paths, recovery.receipt.taskTransfers.flatMap(row => [row.from, row.to]), options.io?.inspect?.() ?? options.processes))) {
+      return executeMove(null, null, paths, { ...options, recover: true, receiptFile: recovery.file })
+    }
+    return finishPending(paths, options)
+  }
   if (!(await latestReceipt(paths))) return { nothing: true, ok: true }
   await resumeLast(paths, { processes: options.processes, receiptFile: options.receiptFile })
   const deferred = await deferredWorkflow(paths)
@@ -3279,7 +3601,7 @@ async function inspectPlaced(paths) {
     receipt.metadataDrift = changed
     await saveJson(file, receipt)
   }
-  return { changed, receipt: file, ok: receiptOkay(receipt), failed: receipt.failed ?? [], problems: receipt.verification?.problems ?? [] }
+  return { changed, receipt: file, ok: finishOkay(receipt), failed: (receipt.failed ?? []).filter(row => row.cloudAccount), notMoved: (receipt.failed ?? []).filter(row => !row.cloudAccount), problems: receipt.verification?.problems ?? [] }
 }
 
 export const verifyPlaced = (paths) => locked(paths, () => inspectPlaced(paths))
@@ -3294,7 +3616,7 @@ export async function sweep(paths, options = {}) {
     const error = result.reason ?? result.problems?.map((row) => `${row.title}: ${row.check}`).join(', ') ?? result.receipt?.failed.map((row) => `${row.title}: ${row.error}`).join(', ')
     return { verification, result, error: result.ok === false ? error || 'Pending local work needs attention' : null, refreshRequired: !result.receipt?.held.length && result.added > 0 && sameAccount(await signedIn(paths), result.receipt?.toAccount), ok: result.ok !== false }
   }
-  if (!deferred || deferred.mode !== 'cloud') return { verification, ok: !verification.error, complete: !deferred && verification.ok === true }
+  if (!deferred || deferred.mode !== 'cloud') return { verification, ok: !verification.error && verification.ok !== false, complete: !deferred && verification.ok === true }
   const active = options.active ?? await signedIn(paths, options.processes)
   const source = deferred.sources.find((row) => sameAccount(row, active))
   if (!source) return { verification, pending: true, ok: true }
@@ -3308,46 +3630,57 @@ export async function sweep(paths, options = {}) {
   }
 }
 
-export function undo(paths, options = {}) {
-  return locked(paths, async () => {
-    const reconciled = await reconcile(paths, options)
-    if (reconciled?.undo) return reconciled.undo
-    if (reconciled?.pendingUndo) return { receipt: reconciled.receipt, pendingUndo: reconciled.pendingUndo, remoteRestored: reconciled.remoteRestored ?? 0 }
-    if (reconciled) return { reconciled }
-    const latest = await latestReceipt(paths)
-    if (!latest) return { nothing: true }
-    const { file, receipt } = latest
-    if (receipt.retained?.length) return { receipt, retained: receipt.retained }
-    const kept = []
-    const liveWorkers = workers()
-    for (const r of receipt.sessions) {
-      const changes = await targetChanges(r, liveWorkers, r.strategy !== 'rehome')
-      if (changes.length) kept.push(`${r.title} | ${short(r.targetId)} | ${changes.join(', ')} changed`)
-    }
-    if (kept.length) return { receipt, changed: kept }
-    const root = path.join(paths.state, 'quarantine')
-    const blocked = await restoreProblems(receipt.superseded ?? [], root)
-    if (blocked.length) return { receipt, restoreProblems: blocked }
-    const plan = await prepareUndo(receipt, paths)
-    const changedAfterSnapshot = []
-    const finalWorkers = workers()
-    for (const r of receipt.sessions) {
-      const changes = await targetChanges(r, finalWorkers, r.strategy !== 'rehome')
-      if (changes.length) changedAfterSnapshot.push(`${r.title} | ${short(r.targetId)} | ${changes.join(', ')} changed`)
-    }
-    if (changedAfterSnapshot.length) return { receipt, changed: changedAfterSnapshot }
-    const activationBlocked = await activationProblems(receipt)
-    activationBlocked.push(...await undoParentProblems(receipt))
-    if (activationBlocked.length) return { receipt, restoreProblems: activationBlocked }
-    receipt.undoing = plan
-    if (receipt.remote?.length) receipt.remoteUndoing = structuredClone(receipt.remote)
-    cancelCloudChecks(receipt)
-    await saveJson(file, receipt)
-    const remote = await restoreRemote(receipt, file, paths, options.cloud)
-    if (remote.problems.length) return { receipt, restoreProblems: remote.problems }
-    if (remote.pending.length) return { receipt, pendingUndo: remote.pending, remoteRestored: remote.restored }
-    return finishUndo(receipt, file, paths)
-  })
+export async function undo(paths, options = {}) {
+  const recovery = await recoveryPending(paths)
+  if (options.approve && recovery?.receipt?.taskTransfers?.length) return executeMove(null, null, paths, { ...options, recover: true, receiptFile: recovery.file })
+  const result = await locked(paths, () => undoFiles(paths, options))
+  if (!result.restartNeeded) return result
+  return executeMove(null, null, paths, { ...options, undo: !result.receipt.undoing, recover: Boolean(result.receipt.undoing), receiptFile: result.file })
+}
+
+async function undoFiles(paths, options = {}) {
+  const reconciled = options.check ? null : await reconcile(paths, options)
+  if (reconciled?.undo) return reconciled.undo
+  if (reconciled?.pendingUndo) return { receipt: reconciled.receipt, pendingUndo: reconciled.pendingUndo, remoteRestored: reconciled.remoteRestored ?? 0 }
+  if (reconciled) return { reconciled }
+  const latest = await latestReceipt(paths)
+  if (!latest) return { nothing: true }
+  const { file, receipt } = latest
+  if (receipt.retained?.length) return { receipt, retained: receipt.retained }
+  const kept = []
+  const inspect = options.inspect ?? options.io?.inspect ?? (() => options.processes ?? processTable(paths.claudeApp))
+  const liveWorkers = workers(inspect())
+  for (const r of receipt.sessions) {
+    const changes = await targetChanges(r, liveWorkers, r.strategy !== 'rehome')
+    if (changes.length) kept.push(`${r.title} | ${short(r.targetId)} | ${changes.join(', ')} changed`)
+  }
+  if (kept.length) return { receipt, changed: kept }
+  const root = path.join(paths.state, 'quarantine')
+  const blocked = [...await restoreProblems(receipt.superseded ?? [], root),
+    ...await taskTransferProblems(receipt.taskTransfers, paths, inspect) ]
+  const schedulerHeld = blocked.length > 0 && blocked.every(problem => problem === SCHEDULER_OWNS) && !options.check
+  if (schedulerHeld && !receipt.remote?.length) return { restartNeeded: true, file, receipt }
+  if (blocked.length && !schedulerHeld) return { receipt, restoreProblems: blocked }
+  const plan = await prepareUndo(receipt, paths)
+  const changedAfterSnapshot = []
+  const finalWorkers = workers(inspect())
+  for (const r of receipt.sessions) {
+    const changes = await targetChanges(r, finalWorkers, r.strategy !== 'rehome')
+    if (changes.length) changedAfterSnapshot.push(`${r.title} | ${short(r.targetId)} | ${changes.join(', ')} changed`)
+  }
+  if (changedAfterSnapshot.length) return { receipt, changed: changedAfterSnapshot }
+  const activationBlocked = await activationProblems(receipt)
+  activationBlocked.push(...await undoParentProblems(receipt), ...(await taskTransferProblems(receipt.taskTransfers, paths, inspect)).filter(problem => !schedulerHeld || problem !== SCHEDULER_OWNS))
+  if (activationBlocked.length) return { receipt, restoreProblems: activationBlocked }
+  receipt.undoing = plan
+  if (receipt.remote?.length) receipt.remoteUndoing = structuredClone(receipt.remote)
+  cancelCloudChecks(receipt)
+  await saveJson(file, receipt)
+  const remote = await restoreRemote(receipt, file, paths, options.cloud)
+  if (remote.problems.length) return { receipt, restoreProblems: remote.problems }
+  if (remote.pending.length) return { receipt, pendingUndo: remote.pending, remoteRestored: remote.restored }
+  if (schedulerHeld) return { restartNeeded: true, file, receipt }
+  return finishUndo(receipt, file, paths, { ...options, inspect })
 }
 
 function describe(list) {
@@ -3553,11 +3886,11 @@ function parse(argv) {
   if ((args.from.length > 0) !== Boolean(args.to)) throw new Error('--from and --to go together')
   if ((args.help || args.version) && argv.length > 1) throw new Error(`${args.help ? '--help' : '--version'} goes alone`)
   const incompatible = args.from.length || args.to || args.dry || args.cloud || args.remove || args.snapshot
-  if (['accounts', 'keep-local', 'undo', 'sweep'].includes(args.cmd) && (incompatible || args.restartApproved || args.moveOnly)) throw new Error(`${args.cmd} accepts only --json`)
-  if (args.cmd === 'finish' && incompatible) throw new Error('finish accepts only --json and --restart-approved')
+  if (['accounts', 'keep-local', 'sweep'].includes(args.cmd) && (incompatible || args.restartApproved || args.moveOnly)) throw new Error(`${args.cmd} accepts only --json`)
+  if (['finish', 'undo'].includes(args.cmd) && (incompatible || args.cmd === 'undo' && args.moveOnly)) throw new Error(`${args.cmd} accepts only --json and --restart-approved`)
   if (args.restartApproved && !/^[a-f0-9]{64}$/.test(args.restartApproved)) throw new Error('restart approval token must be the one displayed by the engine')
   if (args.moveOnly && (args.restartApproved || args.dry || (args.cmd && args.cmd !== 'finish'))) throw new Error('--move-only applies only to a move or held continuation')
-  if (args.restartApproved && (args.dry || (args.cmd && !['restart', 'finish'].includes(args.cmd)))) throw new Error('restart approval applies only to a move or restart')
+  if (args.restartApproved && (args.dry || (args.cmd && !['restart', 'finish', 'undo'].includes(args.cmd)))) throw new Error('restart approval applies only to a move, finish, undo, or restart')
   if (args.cmd === 'restart' && incompatible) throw new Error('restart accepts only --json and --restart-approved')
   if (args.cmd === 'menubar' && (args.from.length || args.to || args.dry || args.cloud || args.json || (args.remove && args.snapshot))) throw new Error('menubar accepts only --remove or --snapshot <png>')
   if (args.cmd !== 'menubar' && (args.remove || args.snapshot)) throw new Error('--remove and --snapshot require menubar')
@@ -3576,7 +3909,7 @@ async function main(argv) {
   const emit = (o) => out.write(`${JSON.stringify(o)}\n`)
   const showPlan = (plan) => {
     if (args.json) return emit({ plan: true, ...plan })
-    const selection = plan.resume ? 'finish' : plan.selection ? `${plan.selection.from.map((a) => `--from "${a.account} ${a.org}"`).join(' ')} --to "${plan.selection.to.account} ${plan.selection.to.org}"` : 'restart'
+    const selection = plan.kind === 'undo' ? 'undo' : plan.kind === 'recover' ? 'finish' : plan.resume ? 'finish' : plan.selection ? `${plan.selection.from.map((a) => `--from "${a.account} ${a.org}"`).join(' ')} --to "${plan.selection.to.account} ${plan.selection.to.org}"` : 'restart'
     out.write(`  restart     Claude Desktop must close before this operation\n  affected    ${[...new Set(plan.affected.map((row) => row.title))].join(', ') || 'no Code workers'}\n  approve     claude-transplant ${selection} --restart-approved ${plan.token}${args.cloud ? ' --cloud' : ''}\n`)
   }
   const showMove = async (result) => {
@@ -3621,11 +3954,13 @@ async function main(argv) {
   if (args.cmd === 'menubar') return out.write(`${await locked(paths, () => menubar(paths, args.remove, args.snapshot))}\n`)
   if (args.cmd === 'sweep') {
     const result = await sweep(paths)
-    const failed = result.result?.receipt?.failed ?? result.verification?.failed ?? []
+    const failed = result.result?.failed ?? result.result?.receipt?.failed ?? result.verification?.failed ?? []
+    const notMoved = result.result?.notMoved ?? result.verification?.notMoved ?? []
     const problems = result.result?.receipt?.verification?.problems ?? result.verification?.problems ?? []
-    const error = result.error ?? result.verification?.error ?? (problems.length ? problems.map(problemText).join(', ') : null)
+    const error = result.error ?? result.verification?.error ?? (problems.length ? problems.map(problemText).join(', ') : !result.ok ? failed.map(row => `${row.title || row.id} | ${row.error}`).join(', ') || 'The previous move failed verification' : null)
+    if (!result.ok || error) process.exitCode = 1
     if (args.json) return emit({ swept: true, ok: result.ok && !error, error, changed: result.verification?.changed ?? [], recovered: result.recovered,
-      receipt: result.result?.file ?? result.verification?.receipt, failed, problems,
+      receipt: result.result?.file ?? result.verification?.receipt, failed, notMoved, problems,
       pendingLocal: result.result?.pendingLocal, restart: result.refreshRequired, cloudChecked: result.result?.cloudChecked ?? 0, cloudArchived: result.result?.cloudArchived ?? 0, complete: result.result?.complete ?? result.complete })
     return out.write(error ? `${error}\n` : `${quantity(result.verification?.changed.length ?? 0, 'metadata change')} detected\n`)
   }
@@ -3643,7 +3978,7 @@ async function main(argv) {
       if (result.nothing) return emit({ nothing: true })
       if (result.recoveryRequired) return emit({ done: true, ok: false, recoveryRequired: true, reason: 'Recovery must finish before cloud checks can be cancelled' })
       if (result.refused) return emit({ refused: result.refused, reason: 'Keep local refused because a rescued target failed verification' })
-      return emit({ done: true, ok: result.ok, complete: result.complete, keptLocal: result.cancelled, heldCancelled: result.heldCancelled, labels: result.labels, failed: result.receipt.failed, problems: result.receipt.verification?.problems ?? [] })
+      return emit({ done: true, ok: result.ok, complete: result.complete, keptLocal: result.cancelled, heldCancelled: result.heldCancelled, labels: result.labels, failed: result.failed, notMoved: result.notMoved, problems: result.receipt.verification?.problems ?? [] })
     }
     if (result.nothing) return out.write('nothing pending\n')
     if (result.recoveryRequired) return out.write('  refused     recovery must finish before cloud checks can be cancelled\n')
@@ -3680,6 +4015,7 @@ async function main(argv) {
         pendingUndo: result.pendingUndo ?? [],
         pendingLabels: result.pendingLabels ?? result.pendingUndo ?? [],
         failed: result.failed ?? result.receipt?.failed ?? [],
+        notMoved: result.notMoved ?? [],
         problems: result.problems ?? [],
         restart: result.restart ?? false
       })
@@ -3689,15 +4025,22 @@ async function main(argv) {
     if (result.recoveryRequired) return out.write('  pending     recovery remains incomplete\n')
     if (result.dest) return out.write(`Undo  ${result.receipt.at} completed\n`)
     if (result.pendingUndo?.length) return out.write(`  pending     sign Claude Desktop into ${result.pendingUndo.join(' or ')} and run finish again\n`)
+    if (result.reason) out.write(`  failed      ${result.reason}\n`)
     if (result.failed?.length) out.write(`  ${result.nothing ? 'not moved' : 'failed   '}   ${result.failed.map((failure) => `${failure.title || failure.id} | ${failure.error}`).join('\n              ')}\n`)
+    if (result.notMoved?.length) out.write(`  not moved   ${result.notMoved.map(row => `${row.title || row.id} | ${row.error}`).join('\n              ')}\n`)
     if (result.problems?.length) out.write(`  failed      ${result.problems.map(problemText).join('\n              ')}\n`)
     if (result.nothing) return
     const pending = result.pendingLabels?.length ? ` | ${result.pendingLabels.join(', ')}` : ''
     return out.write(result.complete ? '  cloud       all source checks complete\n' : `  pending     ${result.pendingCloud} cloud checks${pending}\n`)
   }
   if (args.cmd === 'undo') {
-    const result = await undo(paths)
-    if (result.changed || result.retained || result.restoreProblems || result.reconciled || result.pendingUndo) process.exitCode = 1
+    const result = await undo(paths, { approve: args.restartApproved, approvalStartedAt: began, report: reporter(args.json) })
+    if (result.plan) return showPlan(result.plan)
+    if (result.reason && !result.receipt) {
+      process.exitCode = 1
+      return args.json ? emit({ done: true, ok: false, reason: result.reason }) : out.write(`${result.reason}\n`)
+    }
+    if (result.ok === false || result.changed || result.retained || result.restoreProblems || result.reconciled || result.pendingUndo) process.exitCode = 1
     if (args.json) {
       if (result.nothing) return emit({ nothing: true })
       if (result.reconciled) return emit({ reconciled: result.reconciled, retry: true })
@@ -3755,7 +4098,7 @@ async function main(argv) {
         const waiting = source ? deferred.mode === 'local'
           ? waitingSessions({ held: deferred.receipt.held?.filter(held => held.sources.some(member => sameAccount(member, source))), cloudChecks: deferred.receipt.cloudChecks.filter(check => sameAccount(check, source)) })
           : source.waiting ?? [] : []
-        const pendingAction = !source ? null : deferred.mode === 'local' ? waiting.some(row => ownsWorker(workers(table), row.localId, row.recordId)) ? 'restart' : 'finish' : !active ? 'sign-in'
+        const pendingAction = !source ? null : deferred.recovery ? 'finish' : deferred.mode === 'local' ? waiting.some(row => ownsWorker(workers(table), row.localId, row.recordId)) ? 'restart' : 'finish' : !active ? 'sign-in'
           : waiting.length ? canRestartWaiting({ cloudChecks: [source] }, table) ? 'restart' : 'wait' : 'finish'
         return {
           account,

--- a/transplant.js
+++ b/transplant.js
@@ -71,6 +71,8 @@ const waitingSessions = (receipt) => [...new Map([
 ].map(row => [row.localId ?? remoteId(row.id) ?? row.id, row])).values()]
 const legacyLocalFailures = (receipt) => receipt.localCancelledAt ? [] : (receipt.failed ?? []).filter(row => row.error === WORKER_OWNS && UUID.test(row.id ?? ''))
 const needsRecovery = (receipt) => Boolean(receipt.pending || receipt.retiring || receipt.finalizing || receipt.undoing || receipt.remotePending || receipt.remoteUndoing?.length)
+const recoveryFamilies = (receipt) => (receipt.taskTransfers ?? []).slice(receipt.undoing ? 0 : receipt.appendCheckpoint?.taskTransfers ?? 0)
+const inspector = (paths, options) => options.inspect ?? options.io?.inspect ?? (() => options.processes ?? processTable(paths.claudeApp))
 const receiptOkay = (receipt) => receipt.verification?.ok !== false && !receipt.failed?.length
 const finishOkay = (receipt) => receipt.verification?.ok !== false && !receipt.verification?.problems?.length &&
   !(receipt.failed ?? []).some(row => row.cloudAccount) && !receipt.cloudError
@@ -1562,7 +1564,6 @@ async function rehomeOne(s, to, journal, guard) {
   const recordSha = sha(recordText)
   await journal({ strategy: 'rehome', recordSha })
   guard.check?.()
-  await guard.taskCheck?.()
   await writeNew(record, recordText, async ({ dev, ino }) => {
     guard.created.set(record, { dev, ino })
     await journal({ created: { dev, ino } })
@@ -1576,7 +1577,6 @@ async function rehomeOne(s, to, journal, guard) {
   if (sha(afterRecord) !== sourceRecordSha) throw new Error('source Desktop record changed during move')
   if (afterSidecars.fingerprint !== sourceSidecars.fingerprint) throw new Error('source sidecars changed during move')
   guard.check?.()
-  await guard.taskCheck?.()
   for (const member of s.members ?? [s]) {
     member.strategy = 'rehome'
     member.transcriptFingerprint = transcriptFingerprint
@@ -1770,7 +1770,7 @@ async function deferredWorkflow(paths) {
     return { ...latest, mode: 'undo', sources }
   }
   if ((receipt.pending || receipt.retiring || receipt.finalizing || receipt.undoing) && receipt.taskTransfers?.length) {
-    const transfers = receipt.undoing ? receipt.taskTransfers : receipt.taskTransfers.slice(receipt.appendCheckpoint?.taskTransfers ?? 0)
+    const transfers = recoveryFamilies(receipt)
     const sources = [...new Map(transfers.map(row => [`${row.from.account}/${row.from.org}`, row.from])).values()]
     if (sources.length) return { ...latest, mode: receipt.undoing ? 'undo' : 'recovery', recovery: true, sources }
   }
@@ -1905,7 +1905,11 @@ async function taskTransferProblems(transfers, paths, inspect, partial = false, 
   for (const family of transfers ?? []) {
     check()
     try {
+      const ids = new Set(family.ids), recordIds = new Set(family.recordIds)
+      const links = new Map(family.links.map(link => [link[0], stable(link)])), cliIds = new Set(family.links.map(link => link[1]))
+      const expectedTasks = stable(family.tasks.toSorted((a, b) => a.id.localeCompare(b.id)))
       const table = inspect?.() ?? processTable(paths.claudeApp)
+      const liveWorkers = new Set(table.filter(row => row.worker).flatMap(row => row.ids))
       if (await schedulerBusy(paths, [family.from, family.to], table)) problems.push(SCHEDULER_OWNS)
       if (sameAccount(family.from, family.to)) throw new Error('scheduled task namespaces must differ')
       const selected = []
@@ -1913,23 +1917,27 @@ async function taskTransferProblems(transfers, paths, inspect, partial = false, 
         if (!UUID.test(namespace.account) || !UUID.test(namespace.org) || file !== path.join(paths.records, namespace.account, namespace.org, 'scheduled-tasks.json')) throw new Error('scheduled task namespace mismatch')
         const registry = (await taskSessions(file)).registry
         const tasks = registry?.scheduledTasks ?? []
-        const owned = tasks.filter(task => family.ids.includes(task.id))
-        if (owned.length && stable(owned.toSorted((a, b) => a.id.localeCompare(b.id))) !== stable(family.tasks.toSorted((a, b) => a.id.localeCompare(b.id)))) throw new Error('scheduled task registrations changed')
-        if (tasks.some(task => !family.ids.includes(task.id) && family.recordIds.includes(task.notifySessionId))) throw new Error('new scheduled task dependency')
+        const owned = tasks.filter(task => ids.has(task.id))
+        if (owned.length && stable(owned.toSorted((a, b) => a.id.localeCompare(b.id))) !== expectedTasks) throw new Error('scheduled task registrations changed')
+        if (tasks.some(task => !ids.has(task.id) && recordIds.has(task.notifySessionId))) throw new Error('new scheduled task dependency')
         if (family.state) {
           const expected = owned.length ? family.state : file === family.targetFile ? family.targetState : taskState(null, [])
           if (stable(taskState(registry, family.ids)) !== stable(expected)) throw new Error('scheduled task state changed')
         }
         selected.push(owned.length > 0)
-        for (const recordFile of await recordFiles(path.dirname(file))) {
+        const files = await recordFiles(path.dirname(file)).catch(error => {
+          if (file === family.targetFile && error.code === 'ENOENT') return []
+          throw error
+        })
+        for (const recordFile of files) {
           check()
           const record = await readJson(recordFile)
           if (!record || typeof record !== 'object' || Array.isArray(record)) throw new Error('unreadable scheduled task family dependency')
-          const member = family.recordIds.includes(record.sessionId)
-          if (!member && file === family.targetFile && family.links.some(link => link[1] === record.cliSessionId)) throw new Error('target scheduled task session id collision')
-          if (!member && (family.ids.includes(record.scheduledTaskId) || family.recordIds.includes(record.notifySessionId) || family.recordIds.includes(record.forkedFromSessionId))) throw new Error('new scheduled task family dependency')
-          if (member && (!validDesktopRecord({ file: recordFile, record }) || !family.links.some(link => stable(link) === stable(taskLinks(record))))) throw new Error('scheduled task family identity or route changed')
-          if (table.some(worker => worker.worker && ownsWorker(new Set(worker.ids), record.cliSessionId, record.sessionId)) && member) throw new Error('running worker owns scheduled task family')
+          const member = recordIds.has(record.sessionId)
+          if (!member && file === family.targetFile && cliIds.has(record.cliSessionId)) throw new Error('target scheduled task session id collision')
+          if (!member && (ids.has(record.scheduledTaskId) || recordIds.has(record.notifySessionId) || recordIds.has(record.forkedFromSessionId))) throw new Error('new scheduled task family dependency')
+          if (member && (!validDesktopRecord({ file: recordFile, record }) || links.get(record.sessionId) !== stable(taskLinks(record)))) throw new Error('scheduled task family identity or route changed')
+          if (member && ownsWorker(liveWorkers, record.cliSessionId, record.sessionId)) throw new Error('running worker owns scheduled task family')
         }
       }
       if (family.tasks.length && (selected.every(Boolean) || !partial && (selected[0] || !selected[1]))) throw new Error('scheduled task ownership changed')
@@ -1970,6 +1978,8 @@ async function writeTaskRegistrations(transfers, side, present, paths, inspect, 
     const remove = !present && side === 'target' && !family.targetExisted && !Object.keys(after).length
     if (remove) await unlink(file)
     else await saveText(file, jsonText(after), async () => {
+      const problems = await taskTransferProblems([family], paths, inspect, true, check)
+      if (problems.length) throw new Error(problems.join(', '))
       check(true)
       if (stable((await taskSessions(file)).registry) !== stable(registry)) throw new Error('scheduled task registry changed before publication')
       if (await schedulerBusy(paths, [family.from, family.to], inspect?.())) throw new Error(SCHEDULER_OWNS)
@@ -1986,7 +1996,7 @@ async function finishUndo(receipt, file, paths, options = {}) {
     ...await restoreProblems(superseded, root),
     ...await restoreProblems(undoing, root),
     ...await activationProblems(receipt),
-    ...await taskTransferProblems(receipt.taskTransfers, paths, options.inspect ?? options.io?.inspect ?? (() => options.processes ?? processTable(paths.claudeApp)), true, options.check)
+    ...await taskTransferProblems(receipt.taskTransfers, paths, inspector(paths, options), true, options.check)
   ]
   if (await exists(path.join(dest, 'receipt.json'))) problems.push('undo receipt path occupied')
   const liveWorkers = workers()
@@ -1997,7 +2007,7 @@ async function finishUndo(receipt, file, paths, options = {}) {
   problems.push(...await undoParentProblems(receipt))
   if (problems.length) return { receipt, restoreProblems: problems }
   let failure
-  const inspect = options.inspect ?? options.io?.inspect ?? (() => options.processes ?? processTable(paths.claudeApp))
+  const inspect = inspector(paths, options)
   try {
     await writeTaskRegistrations(receipt.taskTransfers, 'target', false, paths, inspect, options.check)
     await restore(superseded, root, options.check)
@@ -2120,9 +2130,10 @@ async function reconcileFiles(paths, options = {}) {
     return { title: p.name, error: 'corrupt receipt set aside' }
   }
   const { receipt } = p
-  const inspect = options.inspect ?? options.io?.inspect ?? (() => options.processes ?? processTable(paths.claudeApp))
+  const inspect = inspector(paths, options)
   const checkpoint = receipt.appendCheckpoint
-  const taskProblems = await taskTransferProblems(receipt.undoing ? receipt.taskTransfers : (receipt.taskTransfers ?? []).slice(checkpoint?.taskTransfers ?? 0), paths, inspect, true, options.check)
+  const taskTransfers = recoveryFamilies(receipt)
+  const taskProblems = await taskTransferProblems(taskTransfers, paths, inspect, true, options.check)
   if (taskProblems.length && !(receipt.undoing && receipt.remoteUndoing?.length && taskProblems.every(problem => problem === SCHEDULER_OWNS) && !options.check)) return { title: 'scheduled task recovery blocked', error: taskProblems.join(', '), problems: taskProblems }
   if (checkpoint && (!Number.isSafeInteger(checkpoint.sessions) || checkpoint.sessions < 0 || checkpoint.sessions > (receipt.sessions?.length ?? 0) || !Number.isSafeInteger(checkpoint.superseded) || checkpoint.superseded < 0 || checkpoint.superseded > (receipt.superseded?.length ?? 0) || !Array.isArray(checkpoint.held))) return { title: 'recovery blocked', error: 'invalid append checkpoint' }
   receipt.failed ??= []
@@ -2186,7 +2197,7 @@ async function reconcileFiles(paths, options = {}) {
     const used = strategy === 'rehome'
       ? await readFile(made[0]).then((raw) => Boolean(receipt.pending.recordSha && sha(raw) !== receipt.pending.recordSha), () => false)
       : await changed(made[0], targetId, knownOf(receipt.pending))
-    if ((used || foreign) && receipt.taskTransfers?.some(family => family.recordIds.includes(path.basename(made[0], '.json')))) return { title: 'scheduled task recovery blocked', error: 'scheduled task target record changed, recovery remains pending' }
+    if ((used || foreign) && taskTransfers.some(family => family.recordIds.includes(path.basename(made[0], '.json')))) return { title: 'scheduled task recovery blocked', error: 'scheduled task target record changed, recovery remains pending' }
     if (!used && !foreign) await quarantine(made, path.join(paths.state, 'quarantine', receipt.at, 'failed'))
     const changedCopy = strategy === 'rehome' ? 'target record' : 'remote rescue'
     const error = foreign ? 'interrupted, independently created target left in place' : used ? `interrupted, ${changedCopy} changed since, left in place` : 'interrupted'
@@ -2199,7 +2210,6 @@ async function reconcileFiles(paths, options = {}) {
     const checkpoint = receipt.appendCheckpoint
     const root = path.join(paths.state, 'quarantine')
     const superseded = receipt.superseded.slice(checkpoint?.superseded ?? 0)
-    const taskTransfers = (receipt.taskTransfers ?? []).slice(checkpoint?.taskTransfers ?? 0)
     const blocked = await restoreProblems(superseded, root)
     if (blocked.length) return { title: 'recovery blocked', error: blocked.join(', '), problems: blocked }
     await writeTaskRegistrations(taskTransfers, 'target', false, paths, inspect, options.check)
@@ -2993,11 +3003,11 @@ async function transfer(inv, to, paths, report, context = {}) {
   }
   const cloud = { ...inv.cloud, matches: (inv.cloud?.matches ?? []).map(match => {
     const base = match.target.kind === 'rescue' && match.target.base
-    if (base?.kind !== 'move' || !result.receipt.superseded.some(row => row.source && row.moved.some(([file]) => file === base.row.file))) return match
-    const placed = result.receipt.sessions.find(row => row.id === base.id && row.record === path.join(to.dir, path.basename(base.row.file)))
-    if (!placed) return match
-    return { ...match, target: { ...match.target, base: { ...base, kind: 'existing', row: { ...base.row, file: placed.record, record: placed.recordSnapshot,
-      recordSemantic: placed.recordSemantic, recordSha: placed.recordSha, account: to, taskOwned: placed.taskOwned } } } }
+    if (!base) return match
+    const parked = result.receipt.superseded.flatMap(row => row.moved).find(([file]) => file === desktopFileOf(base.row))?.[1]
+    if (!parked) return match
+    const row = { ...base.row, file: parked, ...(base.row.session ? { session: { ...base.row.session, file: parked } } : {}) }
+    return { ...match, target: { ...match.target, base: { ...base, row } } }
   }) }
   result = await transferRecords({ ...inv, cloud, move: [], sources: [], targets: [], there: [], blocked: [], unreadable: [], rejected: [], held: result.receipt.held },
     to, paths, unitReport(true), { ...context, existing: { file, receipt: result.receipt }, wholeOperation: true })
@@ -3080,10 +3090,6 @@ async function transferRecords(inv, to, paths, report, context = {}) {
     for (const row of inv.sources) row.taskOwned = false
   }
   const rehomeGuard = { workers: workers(), taskSessions: new Map(), created: new Map(), check: context.check }
-  if (family) rehomeGuard.taskCheck = async () => {
-    const problems = await taskTransferProblems(receipt.taskTransfers.filter(row => row.key === family.key), paths, inv.inspect, true, context.check)
-    if (problems.length) throw new Error(problems.join(', '))
-  }
   for (const file of new Set([...inv.move.map((row) => row.account.taskFile), to.taskFile])) {
     rehomeGuard.taskSessions.set(file, await taskSessions(file))
   }
@@ -3130,13 +3136,22 @@ async function transferRecords(inv, to, paths, report, context = {}) {
   const priorProblems = context.existing ? receipt.appendCheckpoint.verification?.problems ?? [] : []
   receipt.verification = { ok: ok && receipt.appendCheckpoint?.verification?.ok !== false && !priorProblems.length, problems: [...priorProblems, ...recordedProblems] }
   await save()
+  if (family) {
+    const problems = await taskTransferProblems(recoveryFamilies(receipt), paths, inv.inspect, true, context.check)
+    if (problems.length) throw new Error(problems.join(', '))
+  }
   await retire(inv, to, receipt, paths, at, problems, save, report, context.check)
   if (family) {
     if (!ok || inv.sources.some(source => !receipt.superseded.some(row => row.source && row.moved.some(([file]) => file === source.file)))) throw new Error('scheduled task family did not move completely')
     const transfers = receipt.taskTransfers.filter(row => row.key === family.key)
     await writeTaskRegistrations(transfers, 'target', true, paths, inv.inspect, context.check)
     const tasks = transfers[0].tasks
-    for (const row of receipt.sessions.filter(row => row.taskFamily === family.key)) row.taskOwned = tasks.some(task => task.notifySessionId === row.targetRecordId)
+    const liveWorkers = workers(inv.inspect())
+    for (const row of receipt.sessions.filter(row => row.taskFamily === family.key)) {
+      row.taskOwned = tasks.some(task => task.notifySessionId === row.targetRecordId)
+      context.check?.()
+      if ((await targetChanges(row, liveWorkers, false)).length) throw new Error('scheduled task family target changed during publication')
+    }
     const taskProblems = await taskTransferProblems(transfers, paths, inv.inspect, false, context.check)
     if (taskProblems.length) throw new Error(taskProblems.join(', '))
   }
@@ -3397,12 +3412,28 @@ export function executeMove(from, to, paths, options = {}) {
   options = { ...options, cloudRequested: options.cloudRequested === true || Boolean(options.cloud) }
   const report = options.report ?? (() => {})
   const now = options.io?.now ?? (() => performance.now())
-  const approvedAt = options.approve ? options.approvalStartedAt ?? now() : null
+  const approving = options.approve != null
+  const approvedAt = approving ? options.approvalStartedAt ?? now() : null
   return locked(paths, async () => {
+    const inspect = () => options.io?.inspect?.() ?? options.processes ?? processTable(paths.claudeApp)
+    const kind = options.recover ? 'recover' : options.undo ? 'undo' : from ? 'move' : options.finish ? 'finish' : 'refresh'
+    const receiptFile = (options.resume ? options.resumeFile : options.receiptFile) ?? null
+    const planFile = path.join(paths.state, 'restart-plan.json')
+    const saved = approving ? await readJson(planFile).catch(() => null) : null
+    if (approving && (!saved || saved.token !== options.approve || sha(stable(without(saved, ['token']))) !== saved.token || saved.kind !== kind)) {
+      return { ok: false, reason: 'Restart approval is missing or does not match the saved plan' }
+    }
+    if (saved && (saved.receiptFile ?? null) !== receiptFile) return { ok: false, reason: 'The approved pending receipt changed' }
+    if ((options.undo || options.recover || saved?.receiptFile) && (await latestReceipt(paths))?.file !== receiptFile) return { ok: false, reason: 'The operation receipt changed' }
+    const selection = from ? { from: from.map((account) => ({ ...accountRef(account), files: [...account.sessions, ...account.unreadable].map(desktopFileOf) })), to: accountRef(to) } : null
+    if (saved && (Boolean(saved.selection) !== Boolean(selection) || selection && (!sameAccount(saved.selection.to, selection.to) || saved.selection.from.length !== selection.from.length || !saved.selection.from.every((source) => selection.from.some((row) => sameAccount(row, source)))))) {
+      return { ok: false, reason: 'The selected accounts changed after the restart plan' }
+    }
     const recovery = options.recover ? await recoveryPending(paths) : null
-    if (options.recover && (!recovery?.receipt?.taskTransfers?.length || recovery.file !== options.receiptFile || recovery.receipt.remotePending || recovery.receipt.remoteUndoing?.length)) return { ok: false, reason: 'Task recovery changed or still needs cloud restoration' }
+    const taskTransfers = recovery?.receipt ? recoveryFamilies(recovery.receipt) : []
+    if (options.recover && (!taskTransfers.length || recovery.file !== options.receiptFile || recovery.receipt.remotePending || recovery.receipt.remoteUndoing?.length)) return { ok: false, reason: 'Task recovery changed or still needs cloud restoration' }
     if (recovery) {
-      const problems = (await taskTransferProblems(recovery.receipt.taskTransfers, paths, options.io?.inspect ?? (() => options.processes ?? processTable(paths.claudeApp)), true)).filter(problem => problem !== SCHEDULER_OWNS)
+      const problems = (await taskTransferProblems(taskTransfers, paths, inspect, true)).filter(problem => problem !== SCHEDULER_OWNS)
       if (problems.length) return { ok: false, reason: problems.join(', ') }
     }
     const reconciled = options.recover ? null : await reconcile(paths, options)
@@ -3414,21 +3445,8 @@ export function executeMove(from, to, paths, options = {}) {
     const drift = await inspectPlaced(paths)
     if (drift.changed.length) report('changed', `${quantity(drift.changed.length, 'moved session')} now has different metadata. Evidence saved with the receipt.`)
     if (options.finish && deferred?.file !== options.receiptFile) return { ok: false, reason: 'The pending move changed before its restart' }
-    const receiptFile = existing?.file ?? options.receiptFile ?? null
-    const kind = options.recover ? 'recover' : options.undo ? 'undo' : from ? 'move' : options.finish ? 'finish' : 'refresh'
-    const planFile = path.join(paths.state, 'restart-plan.json')
-    const saved = options.approve ? await readJson(planFile).catch(() => null) : null
-    if (options.approve && (!saved || saved.token !== options.approve || sha(stable(without(saved, ['token']))) !== saved.token || saved.kind !== kind)) {
-      return { ok: false, reason: 'Restart approval is missing or does not match the saved plan' }
-    }
-    if (saved && (saved.receiptFile ?? null) !== receiptFile) return { ok: false, reason: 'The approved pending receipt changed' }
-    const selection = from ? { from: from.map((account) => ({ ...accountRef(account), files: [...account.sessions, ...account.unreadable].map(desktopFileOf) })), to: accountRef(to) } : null
-    if (saved && (Boolean(saved.selection) !== Boolean(selection) || selection && (!sameAccount(saved.selection.to, selection.to) || saved.selection.from.length !== selection.from.length || !saved.selection.from.every((source) => selection.from.some((row) => sameAccount(row, source)))))) {
-      return { ok: false, reason: 'The selected accounts changed after the restart plan' }
-    }
     const chosen = saved?.selection ?? selection
     const requestedAt = saved?.requestedAt ?? existing?.receipt.startedAt ?? options.requestedAt ?? new Date().toISOString()
-    const inspect = () => options.io?.inspect?.() ?? options.processes ?? processTable(paths.claudeApp)
     const replan = async (cloud = null, check = () => {}) => {
       check()
       const latest = await accounts(paths)
@@ -3539,8 +3557,9 @@ async function completeActiveCloud(result, paths, options = {}) {
 export async function finishWorkflow(paths, options = {}) {
   const recovery = await recoveryPending(paths)
   if (recovery) {
-    if (!options.background && recovery.receipt?.taskTransfers?.length && !recovery.receipt.remotePending && !recovery.receipt.remoteUndoing?.length &&
-      (options.approve || await schedulerBusy(paths, recovery.receipt.taskTransfers.flatMap(row => [row.from, row.to]), options.io?.inspect?.() ?? options.processes))) {
+    const taskTransfers = recovery.receipt ? recoveryFamilies(recovery.receipt) : []
+    if (!options.background && taskTransfers.length && !recovery.receipt.remotePending && !recovery.receipt.remoteUndoing?.length &&
+      (options.approve || await schedulerBusy(paths, taskTransfers.flatMap(row => [row.from, row.to]), options.io?.inspect?.() ?? options.processes))) {
       return executeMove(null, null, paths, { ...options, recover: true, receiptFile: recovery.file })
     }
     return finishPending(paths, options)
@@ -3631,24 +3650,30 @@ export async function sweep(paths, options = {}) {
 }
 
 export async function undo(paths, options = {}) {
-  const recovery = await recoveryPending(paths)
-  if (options.approve && recovery?.receipt?.taskTransfers?.length) return executeMove(null, null, paths, { ...options, recover: true, receiptFile: recovery.file })
+  if (options.approve != null) {
+    const recovery = await recoveryPending(paths)
+    const recover = Boolean(recovery?.receipt?.taskTransfers?.length)
+    const latest = recovery ?? await latestReceipt(paths)
+    return executeMove(null, null, paths, { ...options, undo: !recover, recover, receiptFile: latest?.file })
+  }
   const result = await locked(paths, () => undoFiles(paths, options))
   if (!result.restartNeeded) return result
   return executeMove(null, null, paths, { ...options, undo: !result.receipt.undoing, recover: Boolean(result.receipt.undoing), receiptFile: result.file })
 }
 
 async function undoFiles(paths, options = {}) {
+  if (options.receiptFile && (await latestReceipt(paths))?.file !== options.receiptFile) return { ok: false, reason: 'The operation receipt changed' }
   const reconciled = options.check ? null : await reconcile(paths, options)
   if (reconciled?.undo) return reconciled.undo
   if (reconciled?.pendingUndo) return { receipt: reconciled.receipt, pendingUndo: reconciled.pendingUndo, remoteRestored: reconciled.remoteRestored ?? 0 }
   if (reconciled) return { reconciled }
   const latest = await latestReceipt(paths)
+  if (options.receiptFile && latest?.file !== options.receiptFile) return { ok: false, reason: 'The operation receipt changed' }
   if (!latest) return { nothing: true }
   const { file, receipt } = latest
   if (receipt.retained?.length) return { receipt, retained: receipt.retained }
   const kept = []
-  const inspect = options.inspect ?? options.io?.inspect ?? (() => options.processes ?? processTable(paths.claudeApp))
+  const inspect = inspector(paths, options)
   const liveWorkers = workers(inspect())
   for (const r of receipt.sessions) {
     const changes = await targetChanges(r, liveWorkers, r.strategy !== 'rehome')

--- a/transplant.js
+++ b/transplant.js
@@ -33,8 +33,8 @@ const HELP = `claude-transplant   move Claude Code history between accounts
 
   claude-transplant             pick from → to, move, retire the source entries, print receipt
   claude-transplant --dry-run   plan only, write nothing, refuses while a move or recovery is pending
-  claude-transplant undo        quarantine the last move, put the source entries back
-  claude-transplant finish      finish held local records or active-source cloud work
+  claude-transplant undo        restore source entries and task registrations, with restart approval if needed
+  claude-transplant finish      recover interrupted transfers, finish held records or active-source cloud work
   claude-transplant keep-local  cancel held work and cloud checks, keep completed moves
   claude-transplant accounts    list accounts
   claude-transplant restart     plan an explicit Desktop restart
@@ -1773,8 +1773,8 @@ async function latestReceipt(paths) {
   return receipt ? { name, file, receipt } : { name, file, corrupt: true }
 }
 
-async function deferredWorkflow(paths) {
-  const latest = await latestReceipt(paths)
+async function deferredWorkflow(paths, latest) {
+  if (latest === undefined) latest = await latestReceipt(paths)
   if (!latest || latest.corrupt) return null
   const { receipt } = latest
   if (receipt.remoteUndoing?.length) {
@@ -4126,7 +4126,12 @@ async function main(argv) {
   const all = await accounts(paths)
   if (args.cmd === 'accounts') {
     if (args.json) {
-      const deferred = await deferredWorkflow(paths)
+      const latest = await latestReceipt(paths)
+      let recoveryProblem = null
+      const deferred = await deferredWorkflow(paths, latest).catch(error => {
+        recoveryProblem = { receipt: latest.file, error: error.message }
+        return null
+      })
       const table = deferred ? processTable(paths.claudeApp) : []
       return emit(all.map(({ account, org, email, orgName, label, stats, active, signedIn, identityState, sessions, unreadable, activeAt }) => {
         const source = deferred?.sources.find((candidate) => sameAccount(candidate, { account, org }))
@@ -4154,7 +4159,8 @@ async function main(argv) {
           receiptMoved: source ? deferred.receipt.sessions.length : null,
           receiptDestination: source ? `${deferred.receipt.toAccount.account}/${deferred.receipt.toAccount.org}` : null,
           pendingFailures: source?.failures ?? [],
-          receipt: source ? deferred.file : null
+          receipt: source ? deferred.file : null,
+          recoveryProblem
         }
       }))
     }

--- a/transplant.test.js
+++ b/transplant.test.js
@@ -3499,6 +3499,44 @@ async function taskCheckpointFixture() {
   return { ...h, sessions, tasks, sourceFile, targetFile, sourceRegistry, originalRecords }
 }
 
+async function checkpointAccountsFixture() {
+  const h = await taskCheckpointFixture()
+  await interruptTaskFamily({ ...h, interruptAfter: 2 }, 'move', 'source')
+  const file = path.join(h.paths.state, (await readdir(h.paths.state)).find(name => /^\d.*\.json$/.test(name)))
+  const original = await readFile(file), receipt = JSON.parse(original)
+  assert.equal(receipt.taskTransfers.length, 2)
+  assert.deepEqual([receipt.appendCheckpoint.sessions, receipt.appendCheckpoint.superseded, receipt.appendCheckpoint.taskTransfers], [1, 1, 1])
+  receipt.appendCheckpoint.taskTransfers = 0
+  await writeFile(file, JSON.stringify(receipt))
+  const before = await fixtureSnapshot(h)
+  const discovered = (await accounts(h.paths, [])).map(row => [row.account, row.org, row.sessions.length, row.unreadable.length])
+  const corrupted = await cli(h.root, ['accounts', '--json'])
+  assert.equal(corrupted.code, 0, corrupted.stderr)
+  assert.equal(lines(corrupted.stdout).length, 1)
+  const listed = lines(corrupted.stdout)[0]
+  assert.equal(listed.length, 4)
+  assert.deepEqual(listed.map(row => [row.account, row.org, row.sessions, row.unreadable]), discovered)
+  for (const row of listed) {
+    assert.deepEqual(row.recoveryProblem, { receipt: file, error: 'invalid append checkpoint' })
+    assert.equal(row.pending, null)
+    assert.equal(row.pendingAction, null)
+  }
+  assert.deepEqual(await fixtureSnapshot(h), before)
+  await writeFile(file, original)
+  const repairedBefore = await fixtureSnapshot(h)
+  const repaired = await cli(h.root, ['accounts', '--json'])
+  assert.equal(repaired.code, 0, repaired.stderr)
+  const restored = lines(repaired.stdout)[0]
+  assert.ok(restored.every(row => row.recoveryProblem === null))
+  assert.deepEqual(restored.filter(row => row.pending).map(row => [row.account, row.pending, row.pendingAction, row.receipt]), [[h.acct.P, 'recovery', 'finish', file]])
+  assert.deepEqual(await fixtureSnapshot(h), repairedBefore)
+  return { corrupted: corrupted.stdout.trim(), repaired: repaired.stdout.trim() }
+}
+
+test('CLI accounts reports checkpoint corruption without changing recovery data', async () => {
+  await checkpointAccountsFixture()
+})
+
 test('Undo validates every supplied approval before changing records or receipts', async () => {
   for (const scenario of ['stale receipt', 'invalid', 'empty', 'wrong operation', 'consumed', 'stopped scheduler', 'pending recovery']) {
     const h = await taskFamilyFixture(), { from, to } = await h.selection()
@@ -5946,6 +5984,7 @@ test('process registry identifies a new worker without argv ids and rejects stal
 
 test('Swift preserves command, progress, metadata, and completion states', async () => {
   const root = await mkdtemp(path.join(os.tmpdir(), 'ct-swift-state-'))
+  const checkpointAccounts = await checkpointAccountsFixture()
   const h = await taskFamilyFixture(true, 1)
   await interruptTaskFamily(h, 'move', 'target')
   const recoveryAccounts = await cli(h.root, ['accounts', '--json'])
@@ -5959,7 +5998,7 @@ test('Swift preserves command, progress, metadata, and completion states', async
     }
 }
 ` + source.slice(end)
-  source = source.replace('guard !running, !sweeping, !snapshot else { return }', 'guard !running, !sweeping else { return }')
+  source = source.replace('guard canMutate, !sweeping, !snapshot else { return }', 'guard canMutate, !sweeping else { return }')
   source += String.raw`
 @MainActor var requests: [([String], (String) -> Void, (Int32, String) -> Void)] = []
 extension Model {
@@ -6122,6 +6161,59 @@ struct StateChecks {
                 return row
             }), encoding: .utf8)!
         }
+        let corruptedAccounts = String(data: Data(base64Encoded: "CORRUPTED_CHECKPOINT_ACCOUNTS")!, encoding: .utf8)!
+        let repairedAccounts = String(data: Data(base64Encoded: "REPAIRED_CHECKPOINT_ACCOUNTS")!, encoding: .utf8)!
+        let discoveredAccounts = try! JSONDecoder().decode([Account].self, from: Data(corruptedAccounts.utf8))
+        for populated in [false, true] {
+            requests = []
+            let inventory = Model(demo: populated ? Demo.accounts : [])
+            if populated {
+                inventory.note = "An earlier result"
+                inventory.lines = [("metadata", "An earlier detail")]
+                inventory.completion = ("An earlier result", "History verified")
+                inventory.symbol = "info.circle"
+                inventory.badge = "100%"
+                inventory.restartAvailable = true
+            }
+            let previousNote = inventory.note, previousLines = inventory.lines
+            let previousSymbol = inventory.symbol, previousBadge = inventory.badge
+            for _ in 0..<2 {
+                let index = requests.count
+                inventory.refresh()
+                precondition(requests[index].0 == ["accounts", "--json"])
+                requests[index].1(corruptedAccounts)
+                requests[index].2(0, "")
+                precondition(inventory.accounts.map(\.id) == discoveredAccounts.map(\.id))
+                precondition(inventory.accounts.map(\.stats) == discoveredAccounts.map(\.stats))
+                precondition(inventory.displaySummary == "The move receipt needs repair")
+                precondition(inventory.visibleCompletion == nil)
+                precondition(!inventory.canMutate && !inventory.ready && !inventory.pendingReady && !inventory.canKeepLocal)
+                precondition(inventory.recoveryProblem?.receipt == discoveredAccounts[0].recoveryProblem?.receipt)
+                precondition(inventory.detailLines.contains { $0.0 == "recovery" && $0.1 == "Invalid append checkpoint" })
+                precondition(inventory.detailLines.contains { $0.0 == "receipt" && $0.1 == inventory.recoveryProblem?.receipt })
+                precondition(inventory.detailLines.count == previousLines.count + 2)
+                inventory.move()
+                inventory.finishPending()
+                inventory.keepLocal()
+                inventory.undo()
+                inventory.restartDesktop()
+                inventory.checkSweep()
+                precondition(requests.count == index + 1 && !inventory.running && !inventory.sweeping)
+            }
+            let index = requests.count
+            inventory.refresh()
+            requests[index].1(repairedAccounts)
+            requests[index].2(0, "")
+            precondition(inventory.recoveryProblem == nil && inventory.canMutate)
+            precondition(inventory.pendingReady && !inventory.ready && !inventory.canKeepLocal)
+            precondition(inventory.note == previousNote && inventory.lines.elementsEqual(previousLines, by: ==))
+            precondition(inventory.symbol == previousSymbol && inventory.badge == previousBadge)
+            precondition(inventory.restartAvailable == populated)
+            precondition(inventory.detailLines.elementsEqual(previousLines, by: ==))
+            precondition(inventory.displaySummary == (populated ? previousNote : "Finish the interrupted move"))
+            inventory.finishPending()
+            precondition(requests.last!.0 == ["finish", "--json"] && inventory.running)
+        }
         requests = []
         let taskRecovery = Model(demo: try! JSONDecoder().decode([Account].self, from: Data(base64Encoded: "TASK_RECOVERY_ACCOUNTS")!))
         precondition(taskRecovery.pendingReady && !taskRecovery.ready && !taskRecovery.canKeepLocal)
@@ -6234,6 +6326,8 @@ struct StateChecks {
 }
 `
   source = source.replace('TASK_RECOVERY_ACCOUNTS', Buffer.from(recoveryAccounts.stdout.trim()).toString('base64'))
+  source = source.replace('CORRUPTED_CHECKPOINT_ACCOUNTS', Buffer.from(checkpointAccounts.corrupted).toString('base64'))
+  source = source.replace('REPAIRED_CHECKPOINT_ACCOUNTS', Buffer.from(checkpointAccounts.repaired).toString('base64'))
   const file = path.join(root, 'checks.swift'), binary = path.join(root, 'checks')
   await writeFile(file, source)
   await promisify(execFile)('/usr/bin/swiftc', ['-parse-as-library', '-o', binary, file], { timeout: 90_000 })

--- a/transplant.test.js
+++ b/transplant.test.js
@@ -1,5 +1,5 @@
 import assert from 'node:assert/strict'
-import { execFile, spawn, spawnSync } from 'node:child_process'
+import childProcess, { execFile, spawn, spawnSync } from 'node:child_process'
 import { createHash, randomUUID } from 'node:crypto'
 import { once } from 'node:events'
 import { appendFileSync, readFileSync, readdirSync, writeFileSync } from 'node:fs'
@@ -13,6 +13,14 @@ import { promisify } from 'node:util'
 import { accounts, cloudClient, executeMove, finishHeld, finishPending, finishWorkflow, inventory, keepLocal, layout, move, normalize, parseProcesses, restartPlan, resumeLast, semantic, signedIn, step, sweep, undo, verifyPlaced, withDesktopRestart, writeNew } from './transplant.js'
 
 const here = path.dirname(fileURLToPath(import.meta.url))
+const fixtureCommand = run => (file, ...args) => {
+  if (file === '/usr/bin/security') return { status: 1, stdout: '', stderr: 'fixture login unavailable' }
+  if (['/usr/bin/osascript', '/usr/bin/open', '/bin/launchctl'].includes(file)) throw new Error('fixture native command requires a mock')
+  return run(file, ...args)
+}
+childProcess.spawnSync = fixtureCommand(childProcess.spawnSync)
+childProcess.spawn = fixtureCommand(childProcess.spawn)
+syncBuiltinESMExports()
 const SOURCE = '00000000-0000-4000-8000-000000000001'
 const MESSAGES = new Set(['user', 'assistant', 'attachment', 'system'])
 const id = (k) => `00000000-0000-4000-8000-${String(k).padStart(12, '0')}`
@@ -61,7 +69,15 @@ async function moveWithPending(h, from, to, cloud = null) {
   return result
 }
 const branchEntries = (count, session, start) => Array.from({ length: count }, (_, index) => entry(index % 2 ? 'assistant' : 'user', start + index, index ? start + index - 1 : null, session))
-const cli = (home, args) => promisify(execFile)(process.execPath, [path.join(here, 'transplant.js'), ...args], {
+const cli = (home, args) => promisify(execFile)(process.execPath, ['--input-type=module', '-e', `
+  import childProcess from 'node:child_process'
+  import { syncBuiltinESMExports } from 'node:module'
+  childProcess.spawnSync = (${fixtureCommand.toString()})(childProcess.spawnSync)
+  childProcess.spawn = (${fixtureCommand.toString()})(childProcess.spawn)
+  syncBuiltinESMExports()
+  process.argv.splice(1, 0, ${JSON.stringify(path.join(here, 'transplant.js'))})
+  await import(${JSON.stringify(path.join(here, 'transplant.js'))})
+`, '--', ...args], {
   env: { ...process.env, HOME: home },
   cwd: here
 }).then((r) => ({ ...r, code: 0 }), (e) => ({ stdout: e.stdout, stderr: e.stderr, code: e.code }))
@@ -3429,14 +3445,14 @@ async function taskFamilyFixture(enabled = false, taskCount = 2, eventCount = 1)
     await h.write(sid, branchEntries(eventCount, sid, 80 + index * eventCount))
     await h.record('P', sid, rehomeRecord(runs.includes(sid) ? { scheduledTaskId: tasks[index - 1].id, notifySessionId: `local_${SOURCE}` } : {}))
   }
-  const skips = Object.fromEntries(tasks.map(task => [task.id, { scheduledFor: '2026-09-02T00:00:00Z', reason: 'app_closed' }]))
-  const retries = { task_0: { attempt: 2, retryAt: '2026-09-02T00:05:00Z', scheduledFor: '2026-09-02T00:00:00Z' } }
-  const unrelatedSkips = { unrelated_task: { scheduledFor: '2026-09-01T01:00:00Z', reason: 'missed' } }
-  const unrelatedRetries = { unrelated_task: { attempt: 1, retryAt: '2026-09-01T01:05:00Z' } }
+  const skips = Object.fromEntries(tasks.map(task => [task.id, [{ at: '2026-09-02T00:00:00Z', reason: 'app_closed' }]]))
+  const retries = { task_0: { slot: '2026-09-02T00:00:00Z', attempts: 2, notBefore: '2026-09-02T00:05:00Z' } }
+  const unrelatedSkips = { unrelated_task: [{ at: '2026-09-01T01:00:00Z', reason: 'missed' }] }
+  const unrelatedRetries = { unrelated_task: { slot: '2026-09-01T01:00:00Z', attempts: 1, notBefore: '2026-09-01T01:05:00Z' } }
   const sourceRegistry = { scheduledTasks: tasks, recordedSkips: { ...skips, ...unrelatedSkips }, runRetries: { ...retries, ...unrelatedRetries }, sundayAliasBoundaryStamped: true,
     dayFieldsOrBoundaryStamped: false, future: { preserved: 'source' } }
   const targetRegistry = { scheduledTasks: [{ id: 'unrelated_task', enabled: true, cronExpression: '0 0 * * *', filePath: '/tmp/fixture/other.md' }],
-    recordedSkips: { other_task: { scheduledFor: '2026-09-03T00:00:00Z', reason: 'disabled' } }, runRetries: { other_task: { attempt: 3, retryAt: '2026-09-03T00:10:00Z' } }, future: { preserved: 'target' } }
+    recordedSkips: { other_task: [{ at: '2026-09-03T00:00:00Z', reason: 'disabled' }] }, runRetries: { other_task: { slot: '2026-09-03T00:00:00Z', attempts: 3, notBefore: '2026-09-03T00:10:00Z' } }, future: { preserved: 'target' } }
   const sourceAfter = { ...sourceRegistry, scheduledTasks: [], recordedSkips: unrelatedSkips, runRetries: unrelatedRetries }
   const targetAfter = { ...targetRegistry, scheduledTasks: [...targetRegistry.scheduledTasks, ...tasks], recordedSkips: { ...targetRegistry.recordedSkips, ...skips }, runRetries: { ...targetRegistry.runRetries, ...retries } }
   const sourceFile = path.join(h.dir('P'), 'scheduled-tasks.json'), targetFile = path.join(h.dir('T'), 'scheduled-tasks.json')
@@ -3448,6 +3464,182 @@ async function taskFamilyFixture(enabled = false, taskCount = 2, eventCount = 1)
   }
   return { ...h, run, second, cold, tasks, sourceRegistry, targetRegistry, sourceAfter, targetAfter, sourceFile, targetFile, selection }
 }
+
+async function fixtureSnapshot(h, directories = [h.paths.records, h.paths.pool, h.paths.state]) {
+  const files = {}
+  const visit = async dir => {
+    for (const entry of await readdir(dir, { withFileTypes: true }).catch(error => { if (error.code === 'ENOENT') return []; throw error })) {
+      const file = path.join(dir, entry.name)
+      if (entry.isDirectory()) await visit(file)
+      else if (dir !== h.paths.state || /^\d.*\.json(?:\.journal)?$/.test(entry.name)) files[file] = createHash('sha256').update(await readFile(file)).digest('hex')
+    }
+  }
+  for (const dir of directories) await visit(dir)
+  return files
+}
+
+test('Undo validates every supplied approval before changing records or receipts', async () => {
+  for (const scenario of ['stale receipt', 'invalid', 'empty', 'wrong operation', 'consumed', 'stopped scheduler', 'pending recovery']) {
+    const h = await taskFamilyFixture(), { from, to } = await h.selection()
+    const moved = await executeMove([from], to, h.paths, { processes: [] })
+    let rows = [desktopFixture()[0]]
+    const calls = [], io = { inspect: () => rows, command: async file => {
+      calls.push(file)
+      rows = file.endsWith('osascript') ? [] : [{ ...desktopFixture()[0], pid: 700, desktopPid: 700, started: 'reopened' }]
+      return { status: 0 }
+    } }
+    const planned = await (scenario === 'wrong operation' ? executeMove(null, null, h.paths, { io }) : undo(h.paths, { io }))
+    assert.ok(planned.plan, scenario)
+    assert.equal(planned.plan.receiptFile, scenario === 'wrong operation' ? null : moved.file)
+    if (scenario === 'consumed') assert.ok((await undo(h.paths, { io, approve: planned.plan.token })).dest)
+    if (['stale receipt', 'consumed'].includes(scenario)) {
+      const sid = id(798)
+      await h.write(sid, branchEntries(1, sid, 600))
+      await h.record('Q', sid, rehomeRecord())
+      const all = await accounts(h.paths, [])
+      assert.equal((await executeMove([all.find(row => row.account === h.acct.Q)], all.find(row => row.account === h.acct.T), h.paths, { processes: [] })).ok, true)
+    }
+    if (scenario === 'pending recovery') {
+      const receipt = JSON.parse(await readFile(moved.file))
+      receipt.finalizing = true
+      await writeFile(moved.file, JSON.stringify(receipt))
+    }
+    if (scenario === 'stopped scheduler') rows = []
+    calls.length = 0
+    const before = await fixtureSnapshot(h)
+    const refused = await undo(h.paths, { io, approve: scenario === 'empty' ? '' : scenario === 'invalid' || scenario === 'pending recovery' ? '0'.repeat(64) : planned.plan.token })
+    assert.equal(refused.ok, false, scenario)
+    assert.match(refused.reason, /approval|receipt changed|Open Claude sessions changed/, scenario)
+    assert.deepEqual(await fixtureSnapshot(h), before, scenario)
+    assert.equal(calls.some(file => file.endsWith('osascript')), false, scenario)
+  }
+})
+
+test('Undo rechecks its receipt under the lock between preflight and restart planning', async () => {
+  const h = await taskFamilyFixture(), { from, to } = await h.selection(), sid = id(798)
+  await executeMove([from], to, h.paths, { processes: [] })
+  await h.write(sid, branchEntries(1, sid, 600))
+  await h.record('Q', sid, rehomeRecord())
+  const all = await accounts(h.paths, []), original = fs.mkdir
+  let entries = 0, before, rows = [desktopFixture()[0]]
+  fs.mkdir = async (...args) => {
+    if (args[0] === h.paths.state && ++entries === 2) {
+      const next = await executeMove([all.find(row => row.account === h.acct.Q)], all.find(row => row.account === h.acct.T), h.paths, { processes: [] })
+      assert.equal(next.ok, true)
+      before = await fixtureSnapshot(h)
+      rows = []
+    }
+    return original(...args)
+  }
+  syncBuiltinESMExports()
+  let result
+  try { result = await undo(h.paths, { io: { inspect: () => rows, command: async () => assert.fail('stale receipt must not restart') } }) }
+  finally { fs.mkdir = original; syncBuiltinESMExports() }
+  assert.ok(before)
+  assert.equal(result.ok, false)
+  assert.match(result.reason, /receipt changed/)
+  assert.deepEqual(await fixtureSnapshot(h), before)
+})
+
+test('task recovery scopes validation, restart and accounts to the unfinished family', async () => {
+  for (const active of ['T', 'Q']) {
+    const h = await taskFamilyFixture()
+    h.tasks[1].notifySessionId = `local_${h.second}`
+    await h.record('P', h.second, rehomeRecord({ scheduledTaskId: h.tasks[1].id, notifySessionId: `local_${h.second}` }))
+    for (const sid of [SOURCE, h.run]) await rename(path.join(h.dir('P'), `local_${sid}.json`), path.join(h.dir('Q'), `local_${sid}.json`))
+    const firstRegistry = { scheduledTasks: [h.tasks[0]], recordedSkips: { task_0: h.sourceRegistry.recordedSkips.task_0 }, runRetries: { task_0: h.sourceRegistry.runRetries.task_0 } }
+    await writeFile(path.join(h.dir('Q'), 'scheduled-tasks.json'), JSON.stringify(firstRegistry))
+    h.sourceRegistry.scheduledTasks = [h.tasks[1]]
+    delete h.sourceRegistry.recordedSkips.task_0
+    delete h.sourceRegistry.runRetries.task_0
+    await writeFile(h.sourceFile, JSON.stringify(h.sourceRegistry))
+    h.sourceAccounts = [h.acct.Q, h.acct.P]
+    await interruptTaskFamily(h, 'move', 'source')
+    const file = path.join(h.paths.state, (await readdir(h.paths.state)).find(name => /^\d.*\.json$/.test(name)))
+    const interrupted = JSON.parse(await readFile(file))
+    assert.equal(interrupted.taskTransfers.length, 2)
+    assert.equal(interrupted.appendCheckpoint.taskTransfers, 1)
+    const target = JSON.parse(await readFile(h.targetFile)), completed = target.scheduledTasks.find(task => task.id === 'task_0')
+    completed.enabled = true
+    completed.lastRunAt = '2026-09-10T00:00:00Z'
+    await writeFile(h.targetFile, JSON.stringify(target))
+    const originals = await Promise.all([SOURCE, h.run].map(sid => readFile(path.join(h.dir('T'), `local_${sid}.json`))))
+    const badge = lines((await cli(h.root, ['accounts', '--json'])).stdout).at(-1)
+    assert.deepEqual(badge.filter(row => row.pending).map(row => row.account), [h.acct.P])
+    const f = await identityFixture(h)
+    await writeFile(h.paths.desktop, JSON.stringify({ lastKnownAccountUuid: h.acct[active] }))
+    await f.write(f.init(1, h.acct[active], h.org[active]))
+    let rows = f.processes
+    const calls = [], io = { inspect: () => rows, command: async name => {
+      calls.push(name)
+      rows = name.endsWith('osascript') ? [] : f.processes
+      return { status: 0 }
+    } }
+    let result = await finishWorkflow(h.paths, { io })
+    if (active === 'T') {
+      assert.ok(result.plan)
+      assert.equal(result.plan.kind, 'recover')
+      result = await finishWorkflow(h.paths, { io, approve: result.plan.token })
+      assert.equal(result.restarted, true)
+    } else {
+      assert.equal(result.plan, undefined)
+      assert.deepEqual(calls, [])
+    }
+    assert.equal(result.recoveryRequired, true)
+    assert.deepEqual(JSON.parse(await readFile(h.targetFile)), target)
+    assert.deepEqual(JSON.parse(await readFile(h.sourceFile)), h.sourceRegistry)
+    assert.deepEqual(await Promise.all([SOURCE, h.run].map(sid => readFile(path.join(h.dir('T'), `local_${sid}.json`)))), originals)
+    assert.ok(await readFile(path.join(h.dir('P'), `local_${h.second}.json`)))
+    const receipt = JSON.parse(await readFile(file))
+    assert.equal(receipt.taskTransfers.length, 1)
+    assert.equal(receipt.finalizing, false)
+    const before = await fixtureSnapshot(h)
+    const refused = await undo(h.paths, { processes: [] })
+    assert.match(refused.restoreProblems.join(' '), /registrations changed/)
+    assert.deepEqual(await fixtureSnapshot(h), before)
+  }
+})
+
+test('a known account without a Desktop directory receives and undoes a task family', async () => {
+  const h = await taskFamilyFixture()
+  await fs.rm(h.dir('T'), { recursive: true })
+  const { from, to } = await h.selection()
+  assert.deepEqual(to.sessions, [])
+  const moved = await executeMove([from], to, h.paths, { processes: [] })
+  assert.equal(moved.ok, true)
+  assert.equal(moved.receipt.sessions.length, 4)
+  assert.deepEqual(JSON.parse(await readFile(h.targetFile)), { scheduledTasks: h.tasks,
+    recordedSkips: { task_0: h.sourceRegistry.recordedSkips.task_0, task_1: h.sourceRegistry.recordedSkips.task_1 }, runRetries: { task_0: h.sourceRegistry.runRetries.task_0 } })
+  assert.deepEqual(JSON.parse(await readFile(h.sourceFile)), h.sourceAfter)
+  assert.ok((await undo(h.paths, { processes: [] })).dest)
+  assert.deepEqual(await readdir(h.dir('T')), [])
+  assert.deepEqual(JSON.parse(await readFile(h.sourceFile)), h.sourceRegistry)
+  for (const sid of [SOURCE, h.run, h.second, h.cold]) assert.ok(await readFile(path.join(h.dir('P'), `local_${sid}.json`)))
+})
+
+test('task preflight refuses absent sources and unreadable destination data', async () => {
+  for (const scenario of ['missing source', 'unreadable source', 'unreadable target', 'denied target']) {
+    const h = await taskFamilyFixture(), { from, to } = await h.selection()
+    const inv = await inventory([{ ...from, sessions: from.sessions.filter(row => row.id !== h.cold) }], to, h.paths, () => {}, { processes: [] })
+    if (scenario === 'missing source') await fs.rm(h.dir('P'), { recursive: true })
+    if (scenario.startsWith('unreadable')) await writeFile(path.join(h.dir(scenario === 'unreadable source' ? 'P' : 'T'), `local_${id(796)}.json`), '{broken')
+    const before = await fixtureSnapshot(h, [h.paths.records, h.paths.pool]), original = fs.readdir
+    if (scenario === 'denied target') {
+      fs.readdir = async (...args) => {
+        if (args[0] === h.dir('T')) throw Object.assign(new Error('fixture target access denied'), { code: 'EACCES' })
+        return original(...args)
+      }
+      syncBuiltinESMExports()
+    }
+    let result
+    try { result = await move(inv, to, h.paths) }
+    finally { fs.readdir = original; syncBuiltinESMExports() }
+    assert.equal(result.ok, false, scenario)
+    assert.equal(result.receipt.sessions.length, 0, scenario)
+    assert.ok(result.receipt.failed.length, scenario)
+    assert.deepEqual(await fixtureSnapshot(h, [h.paths.records, h.paths.pool]), before, scenario)
+  }
+})
 
 test('task families preserve registration state, generated records and registry fields through Undo', async () => {
   for (const enabled of [false, true]) {
@@ -3531,6 +3723,75 @@ test('task family cloud work follows all local placements and reports the entire
   }
 })
 
+test('deferred cloud rescue preserves a retired destination anchor and rejects changed anchors', async () => {
+  for (const scenario of ['ordinary', 'mixed', 'changed', 'unsafe', 'parked changed']) {
+    const h = await taskFamilyFixture(false, 1), anchor = id(795), remoteId = 'cse_retired_anchor'
+    const prefix = branchEntries(8, h.cold, 800).map(row => ({ ...row, entrypoint: 'anchor-entry' }))
+    await h.write(h.cold, [...prefix, entry('user', 808, 807, h.cold, { version: 'survivor-version', entrypoint: 'survivor-entry' })])
+    const anchorEntries = fork(prefix, h.cold, anchor, 'Anchor').map(row => ({ ...row, cwd: '/tmp/anchor', version: 'anchor-version', entrypoint: 'anchor-entry', gitBranch: 'anchor-branch' }))
+    await h.write(anchor, anchorEntries)
+    await h.record('T', anchor, rehomeRecord({ title: 'Remote anchor', cwd: '/tmp/anchor', originCwd: '/tmp/anchor', sessionSettings: { from: 'anchor' }, remoteMcpServersConfig: [{ name: 'anchor-server' }] }))
+    await h.record('P', h.cold, rehomeRecord({ title: 'Local branch', sessionSettings: { from: 'survivor' } }))
+    const { from, to } = await h.selection(), remote = [...prefix, entry('assistant', 809, 807, remoteId)]
+    let status = 'active', archived = 0
+    const cloud = cloudFixture(h, {
+      list: async () => [remoteSession({ id: remoteId, title: 'Remote anchor', status })],
+      eventRows: async () => remoteRows(remote),
+      session: async () => remoteState(status),
+      archive: async () => { status = 'archived'; archived++ },
+      unarchive: async () => { status = 'active' }
+    })
+    const source = scenario === 'ordinary' ? { ...from, sessions: from.sessions.filter(row => row.id === h.cold) } : from
+    const inv = await inventory([source], to, h.paths, () => {}, { processes: [], cloud })
+    assert.equal(inv.cloud.matches.length, 1)
+    assert.equal(inv.cloud.matches[0].target.base.kind, 'existing')
+    assert.equal(inv.cloud.matches[0].target.base.id, anchor)
+    const file = path.join(h.dir('T'), `local_${anchor}.json`), before = await readFile(file)
+    if (scenario === 'changed') await writeFile(file, JSON.stringify({ ...JSON.parse(before), sessionSettings: { edited: true } }))
+    if (scenario === 'unsafe') await writeFile(h.targetFile, JSON.stringify({ ...h.targetRegistry, scheduledTasks: [...h.targetRegistry.scheduledTasks, { id: 'new_anchor_owner', notifySessionId: `local_${anchor}`, enabled: false }] }))
+    const original = fs.rename
+    let edited = false
+    if (scenario === 'parked changed') {
+      fs.rename = async (...args) => {
+        const result = await original(...args)
+        if (args[0] === file && !edited) {
+          edited = true
+          await writeFile(args[1], JSON.stringify({ ...JSON.parse(before), cwd: '/tmp/changed-anchor' }))
+        }
+        return result
+      }
+      syncBuiltinESMExports()
+    }
+    let result
+    try { result = await move(inv, to, h.paths) }
+    finally { fs.rename = original; syncBuiltinESMExports() }
+    const succeeds = ['ordinary', 'mixed'].includes(scenario)
+    assert.equal(result.ok, succeeds, JSON.stringify({ scenario, failed: result.receipt.failed }))
+    assert.equal(archived, succeeds ? 1 : 0, scenario)
+    assert.equal(status, succeeds ? 'archived' : 'active', scenario)
+    if (succeeds) {
+      assert.equal(result.receipt.superseded.filter(row => !row.source && row.id === anchor).length, 1)
+      assert.equal(await stat(file).catch(() => null), null)
+      const rescued = result.receipt.sessions.find(row => row.strategy === 'remote')
+      assert.equal(rescued.rescueAnchorId, anchor)
+      const record = JSON.parse(await readFile(rescued.record)), entries = lines(await readFile(rescued.targetTranscript, 'utf8')).filter(row => row.message)
+      assert.equal(record.cwd, '/tmp/anchor')
+      assert.deepEqual(record.sessionSettings, { from: 'anchor' })
+      assert.deepEqual(record.remoteMcpServersConfig, [{ name: 'anchor-server' }])
+      assert.ok(entries.every(row => row.cwd === '/tmp/anchor' && row.version === 'anchor-version' && row.entrypoint === 'anchor-entry' && row.gitBranch === 'anchor-branch'))
+      assert.deepEqual(entries.map(row => row.message), remote.map(row => row.message))
+      assert.deepEqual(await readFile(path.join(h.project, `${anchor}.jsonl`), 'utf8'), anchorEntries.map(row => JSON.stringify(row)).join('\n') + '\n')
+      assert.ok((await undo(h.paths, { processes: [], cloud })).dest)
+      assert.deepEqual(await readFile(file), before)
+      assert.equal(status, 'active')
+    } else {
+      assert.equal(result.receipt.sessions.some(row => row.strategy === 'remote'), false)
+      assert.match(result.receipt.failed.map(row => row.error).join(' '), /rescue anchor changed/)
+      if (scenario === 'parked changed') assert.equal(edited, true)
+    }
+  }
+})
+
 test('task family preflight errors cannot modify an earlier completed receipt', async () => {
   const h = await taskFamilyFixture(), { from, to } = await h.selection()
   const ordinary = { ...from, sessions: from.sessions.filter(row => row.id === h.cold) }
@@ -3584,7 +3845,7 @@ test('selected source task state arriving after transfer blocks Undo and recover
     else await executeMove([from], to, h.paths, { processes: [] })
     const before = await readFile(h.sourceFile), target = await readFile(h.targetFile)
     const edited = JSON.parse(before)
-    edited[key].task_0 = { scheduledFor: '2026-09-09T00:00:00Z', retryAt: '2026-09-09T00:05:00Z' }
+    edited[key].task_0 = key === 'recordedSkips' ? [{ at: '2026-09-09T00:00:00Z', reason: 'missed' }] : { slot: '2026-09-09T00:00:00Z', attempts: 1, notBefore: '2026-09-09T00:05:00Z' }
     await writeFile(h.sourceFile, JSON.stringify(edited))
     const refused = await (recovery ? finishWorkflow : undo)(h.paths, { processes: [] })
     assert.match((refused.reconciled?.problems ?? refused.restoreProblems ?? refused.changed).join(' '), /scheduled task state changed/)
@@ -3717,7 +3978,7 @@ async function interruptTaskFamily(h, operation, stage) {
     const paths = layout(${JSON.stringify(h.root)})
     const all = await accounts(paths, [])
     if (${JSON.stringify(operation)} === 'undo') await undo(paths, { processes: [] })
-    else await executeMove([all.find(row => row.account === ${JSON.stringify(h.acct.P)})], all.find(row => row.account === ${JSON.stringify(h.acct.T)}), paths, { processes: [] })
+    else await executeMove(${JSON.stringify(h.sourceAccounts ?? [h.acct.P])}.map(account => all.find(row => row.account === account)), all.find(row => row.account === ${JSON.stringify(h.acct.T)}), paths, { processes: [] })
   `
   const result = await promisify(execFile)(process.execPath, ['--input-type=module', '-e', script], { cwd: here, env: { ...process.env, HOME: h.root } })
     .then(() => 0, error => error.code)
@@ -3819,11 +4080,11 @@ test('task edits and dependencies block Undo and interrupted recovery without ov
     const before = JSON.parse(await readFile(h.targetFile)), changed = structuredClone(before)
     if (change === 'task') changed.scheduledTasks.find(task => task.id === h.tasks[0].id).enabled = true
     else if (change === 'dependency') changed.scheduledTasks.push({ id: 'new_task', notifySessionId: `local_${SOURCE}`, enabled: false })
-    else if (change === 'skip') changed.recordedSkips.task_0.reason = 'edited'
-    else if (change === 'retry') changed.runRetries.task_0.attempt++
+    else if (change === 'skip') changed.recordedSkips.task_0[0].reason = 'edited'
+    else if (change === 'retry') changed.runRetries.task_0.attempts++
     else if (change === 'skip removed') delete changed.recordedSkips.task_0
     else if (change === 'retry removed') delete changed.runRetries.task_0
-    else changed.runRetries.task_1 = { attempt: 1, retryAt: '2026-09-05T00:00:00Z' }
+    else changed.runRetries.task_1 = { slot: '2026-09-05T00:00:00Z', attempts: 1, notBefore: '2026-09-05T00:00:00Z' }
     await writeFile(h.targetFile, JSON.stringify(changed))
     const result = await (recovery ? finishWorkflow : undo)(h.paths, { processes: [] })
     assert.match((result.reconciled?.problems ?? result.restoreProblems ?? result.changed).join(' '), /scheduled task/)
@@ -3841,8 +4102,8 @@ test('task transfer uses final registration state and preserves later unrelated 
   const inv = await inventory([from], to, h.paths, () => {}, { processes: [] })
   h.sourceRegistry.scheduledTasks[0].lastRunAt = '2026-09-02T00:00:00Z'
   h.sourceRegistry.scheduledTasks[0].enabled = true
-  h.sourceRegistry.recordedSkips.task_0.reason = 'missed before transfer'
-  h.sourceRegistry.runRetries.task_0.attempt = 4
+  h.sourceRegistry.recordedSkips.task_0[0].reason = 'missed before transfer'
+  h.sourceRegistry.runRetries.task_0.attempts = 4
   await writeFile(h.sourceFile, JSON.stringify(h.sourceRegistry))
   let changed = false
   const result = await move(inv, to, h.paths, (stage, text, extra) => {
@@ -4011,6 +4272,61 @@ test('registry changes during a task move remain recoverable without lost edits'
   await finishWorkflow(h.paths, { processes: [] })
   assert.deepEqual(JSON.parse(await readFile(h.sourceFile)), { ...h.sourceRegistry, unrelatedEdit: 9 })
   assert.ok(await readFile(path.join(h.dir('T'), `local_${h.cold}.json`)))
+})
+
+test('task transaction boundaries retain late dependencies, worker and record edits for recovery', async () => {
+  for (const phase of ['placement', 'retirement', 'publication']) for (const change of ['registration', 'route', 'external worker', 'source edit', 'target edit', 'account switch']) {
+    const h = await taskFamilyFixture(false, 1), f = await identityFixture(h)
+    await writeFile(h.paths.desktop, JSON.stringify({ lastKnownAccountUuid: h.acct.Z }))
+    await f.write(f.init(1, h.acct.Z, h.org.Z))
+    const { from, to } = await h.selection()
+    let rows = f.processes, injected = false, editedFile, editedBefore, editedAfter
+    const hook = phase === 'placement' ? 'link' : phase === 'retirement' ? 'rename' : 'writeFile', original = fs[hook]
+    const write = fs.writeFile
+    const source = path.join(h.dir('P'), `local_${h.run}.json`), target = path.join(h.dir('T'), `local_${SOURCE}.json`)
+    fs[hook] = async (...args) => {
+      const result = await original(...args)
+      const matches = phase === 'placement' ? args[1] === target : phase === 'retirement' ? args[0] === path.join(h.dir('P'), `local_${SOURCE}.json`) : String(args[0]).startsWith(h.targetFile + '.')
+      if (!matches || injected) return result
+      injected = true
+      if (change === 'external worker') rows = [...rows, { pid: 600, worker: true, ids: [h.run], desktopPid: null }]
+      else if (change === 'account switch') {
+        editedFile = path.join(h.paths.logs, 'main.log')
+        editedBefore = await readFile(editedFile)
+        editedAfter = f.event(2, '[LocalSessionManager] Org changed')
+      } else {
+        editedFile = change === 'registration' ? h.sourceFile : change === 'source edit' ? phase === 'publication' ? path.join(h.dir('P'), `local_${id(797)}.json`) : source : target
+        editedBefore = await readFile(editedFile).catch(error => { if (error.code === 'ENOENT') return null; throw error })
+        const value = editedBefore ? JSON.parse(editedBefore) : { sessionId: `local_${id(797)}`, cliSessionId: id(797), scheduledTaskId: h.tasks[0].id }
+        if (change === 'registration') value.scheduledTasks.push({ id: 'new_dependency', notifySessionId: `local_${SOURCE}`, enabled: false })
+        else if (change === 'route') value.notifySessionId = `local_${id(797)}`
+        else value.title = 'Edited during transfer'
+        editedAfter = JSON.stringify(value)
+      }
+      if (editedFile) await write(editedFile, editedAfter)
+      return result
+    }
+    syncBuiltinESMExports()
+    let result
+    try { result = await executeMove([from], to, h.paths, { io: { inspect: () => rows }, processes: f.processes }) }
+    finally { fs[hook] = original; syncBuiltinESMExports() }
+    assert.equal(injected, true, `${phase}: ${change}`)
+    assert.equal(result.ok, false, `${phase}: ${change}`)
+    if (editedFile) assert.equal(await readFile(editedFile, 'utf8'), editedAfter, `${phase}: ${change}`)
+    assert.deepEqual(JSON.parse(await readFile(h.targetFile)), h.targetRegistry, `${phase}: ${change}`)
+    if (editedFile) {
+      if (editedBefore) await writeFile(editedFile, editedBefore)
+      else await unlink(editedFile)
+    }
+    rows = []
+    if (result.recoveryRequired) await finishWorkflow(h.paths, { processes: [] })
+    assert.deepEqual(JSON.parse(await readFile(h.sourceFile)), h.sourceRegistry, `${phase}: ${change}`)
+    const finished = await finishHeld(h.paths, { processes: [] })
+    assert.equal(finished.ok, true, `${phase}: ${change}`)
+    assert.equal(finished.receipt.sessions.length, 3, `${phase}: ${change}`)
+    assert.ok((await undo(h.paths, { processes: [] })).dest)
+    assert.deepEqual(JSON.parse(await readFile(h.sourceFile)), h.sourceRegistry)
+  }
 })
 
 test('Keep local validates target identity and recovery even when only held work remains', async () => {
@@ -5174,6 +5490,66 @@ test('a thousand source records finish one restart with bounded polling and a li
   assert.ok((await undo(h.paths)).dest)
   assert.equal((await readdir(h.dir('P'))).length, amount)
   assert.equal((await readdir(h.dir('T'))).length, 0)
+})
+
+test('a thousand records in one task family finish the real restart budget with linear reads', async t => {
+  const h = await home(), amount = 1000, first = id(10000)
+  const registry = { scheduledTasks: [{ id: 'large_task', notifySessionId: `local_${first}`, enabled: false, fireAt: 123456 }],
+    recordedSkips: { large_task: [{ at: '2026-09-02T00:00:00Z', reason: 'app_closed' }] },
+    runRetries: { large_task: { slot: '2026-09-02T00:00:00Z', attempts: 2, notBefore: '2026-09-02T00:05:00Z' } } }
+  for (let i = 0; i < amount; i++) {
+    const sid = id(10000 + i)
+    await h.write(sid, [entry('user', 20000 + i, null, sid)])
+    await h.record('P', sid, rehomeRecord(i ? { scheduledTaskId: 'large_task', notifySessionId: `local_${first}` } : {}))
+  }
+  const sourceFile = path.join(h.dir('P'), 'scheduled-tasks.json'), targetFile = path.join(h.dir('T'), 'scheduled-tasks.json')
+  await writeFile(sourceFile, JSON.stringify(registry))
+  const all = await accounts(h.paths, []), from = all.find(row => row.account === h.acct.P), to = all.find(row => row.account === h.acct.T)
+  let rows = [desktopFixture()[0]], recordReads = 0, namespaceReads = 0
+  const calls = [], io = { inspect: () => rows, command: async file => {
+    calls.push(file)
+    rows = file.endsWith('osascript') ? [] : [{ ...desktopFixture()[0], pid: 700, desktopPid: 700, started: 'reopened' }]
+    return { status: 0 }
+  } }
+  const planned = await executeMove([from], to, h.paths, { io })
+  assert.equal(planned.plan.held.length, amount)
+  const read = fs.readFile, list = fs.readdir
+  fs.readFile = async (...args) => {
+    if (/^local_.*\.json$/.test(path.basename(String(args[0])))) recordReads++
+    return read(...args)
+  }
+  fs.readdir = async (...args) => {
+    if ([h.dir('P'), h.dir('T')].includes(args[0])) namespaceReads++
+    return list(...args)
+  }
+  syncBuiltinESMExports()
+  const began = performance.now()
+  let result
+  try { result = await executeMove([from], to, h.paths, { io, approve: planned.plan.token }) }
+  finally { fs.readFile = read; fs.readdir = list; syncBuiltinESMExports() }
+  const seconds = (performance.now() - began) / 1000
+  t.diagnostic(JSON.stringify({ benchmark: 'task-family-1000', root: h.root, seconds, recordReads, namespaceReads,
+    moved: result.receipt?.sessions.length ?? 0, ok: result.ok, reason: result.reason ?? null }))
+  assert.equal(result.ok, true, result.reason)
+  assert.equal(result.restarted, true)
+  assert.deepEqual(calls, ['/usr/bin/osascript', '/usr/bin/open'])
+  assert.equal(result.receipt.sessions.length, amount)
+  assert.equal(result.receipt.superseded.length, amount)
+  assert.equal(result.receipt.taskTransfers.length, 1)
+  assert.equal(result.receipt.finalizing, false)
+  assert.deepEqual(JSON.parse(await readFile(sourceFile)), { scheduledTasks: [], recordedSkips: {}, runRetries: {} })
+  assert.deepEqual(JSON.parse(await readFile(targetFile)), registry)
+  assert.deepEqual(await readdir(h.dir('P')), ['scheduled-tasks.json'])
+  assert.equal((await readdir(h.dir('T'))).filter(name => name.startsWith('local_')).length, amount)
+  assert.ok(recordReads < 80 * amount, `Unexpected record reads: ${recordReads}`)
+  assert.ok(namespaceReads < 80, `Unexpected namespace scans: ${namespaceReads}`)
+  const receipt = JSON.parse(await readFile(result.file))
+  assert.equal(receipt.taskTransfers[0].links.length, amount)
+  assert.equal(receipt.taskTransfers[0].recordIds.length, amount)
+  assert.ok((await undo(h.paths, { processes: [] })).dest)
+  assert.deepEqual(JSON.parse(await readFile(sourceFile)), registry)
+  assert.equal((await readdir(h.dir('P'))).filter(name => name.startsWith('local_')).length, amount)
+  assert.deepEqual(await readdir(h.dir('T')), [])
 })
 
 test('interrupted placement replays complete journal entries and ignores only a torn final append', async () => {

--- a/transplant.test.js
+++ b/transplant.test.js
@@ -463,7 +463,7 @@ test('held continuation shares one receipt and Undo restores both phases', async
   assert.deepEqual(await readdir(h.dir('T')), [])
 })
 
-test('a failed held continuation preserves the earlier completed phase', async () => {
+test('a failed held continuation preserves the earlier completed phase with a legacy checkpoint', async () => {
   const h = await home()
   const cold = id(300)
   await h.write(SOURCE, [entry('user', 1, null, SOURCE)])
@@ -473,6 +473,11 @@ test('a failed held continuation preserves the earlier completed phase', async (
   const all = await accounts(h.paths), from = all.find((row) => row.account === h.acct.P), to = all.find((row) => row.account === h.acct.T)
   const first = await executeMove([from], to, h.paths, { processes: desktopFixture(), moveOnly: true })
   await assert.rejects(finishHeld(h.paths, { processes: [], report: (stage, text) => { if (stage === 'retire' && text === 'checking') throw new Error('interrupted append') } }), /interrupted append/)
+  const interrupted = JSON.parse(await readFile(first.file))
+  assert.equal(interrupted.appendCheckpoint.taskTransfers, 0)
+  delete interrupted.appendCheckpoint.taskTransfers
+  delete interrupted.taskTransfers
+  await writeFile(first.file, JSON.stringify(interrupted))
   const recovered = await undo(h.paths)
   assert.ok(recovered.reconciled)
   const receipt = JSON.parse(await readFile(first.file))
@@ -3478,6 +3483,22 @@ async function fixtureSnapshot(h, directories = [h.paths.records, h.paths.pool, 
   return files
 }
 
+async function taskCheckpointFixture() {
+  const h = await home(), sessions = [SOURCE, id(791)]
+  const sourceFile = path.join(h.dir('P'), 'scheduled-tasks.json'), targetFile = path.join(h.dir('T'), 'scheduled-tasks.json')
+  const tasks = sessions.map((sid, index) => ({ id: `task_${index + 1}`, notifySessionId: `local_${sid}`, enabled: true, fireAt: 123456 + index }))
+  const sourceRegistry = { scheduledTasks: tasks,
+    recordedSkips: Object.fromEntries(tasks.map(task => [task.id, [{ at: '2026-09-02T00:00:00Z', reason: 'app_closed' }]])),
+    runRetries: Object.fromEntries(tasks.map(task => [task.id, { slot: '2026-09-02T00:00:00Z', attempts: 2, notBefore: '2026-09-02T00:05:00Z' }])) }
+  for (const [index, sid] of sessions.entries()) {
+    await h.write(sid, [entry('user', 810 + index, null, sid)])
+    await h.record('P', sid, rehomeRecord())
+  }
+  const originalRecords = await Promise.all(sessions.map(sid => readFile(path.join(h.dir('P'), `local_${sid}.json`))))
+  await writeFile(sourceFile, JSON.stringify(sourceRegistry))
+  return { ...h, sessions, tasks, sourceFile, targetFile, sourceRegistry, originalRecords }
+}
+
 test('Undo validates every supplied approval before changing records or receipts', async () => {
   for (const scenario of ['stale receipt', 'invalid', 'empty', 'wrong operation', 'consumed', 'stopped scheduler', 'pending recovery']) {
     const h = await taskFamilyFixture(), { from, to } = await h.selection()
@@ -3598,6 +3619,106 @@ test('task recovery scopes validation, restart and accounts to the unfinished fa
     assert.match(refused.restoreProblems.join(' '), /registrations changed/)
     assert.deepEqual(await fixtureSnapshot(h), before)
   }
+})
+
+test('task checkpoint integrity refuses corruption before recovery writes or restart', async t => {
+  const checkpoints = [
+    ['inconsistent zero', { taskTransfers: 0 }],
+    ['missing offset', { taskTransfers: undefined }],
+    ['null offset', { taskTransfers: null }],
+    ['negative offset', { taskTransfers: -1 }],
+    ['fractional offset', { taskTransfers: 0.5 }],
+    ['out-of-range offset', { taskTransfers: 3 }],
+    ['uncommitted family offset', { taskTransfers: 2 }],
+    ['missing committed records', { sessions: 0 }],
+    ['missing committed retirement', { superseded: 0 }],
+    ['valid checkpoint', {}]
+  ]
+  for (const mode of ['stopped Desktop', 'approved restart']) for (const [scenario, patch] of checkpoints) await t.test(`${scenario}, ${mode}`, async () => {
+    const h = await taskCheckpointFixture(), { sessions, tasks, sourceFile, targetFile, sourceRegistry, originalRecords } = h
+    await interruptTaskFamily({ ...h, interruptAfter: 2 }, 'move', 'source')
+    const file = path.join(h.paths.state, (await readdir(h.paths.state)).find(name => /^\d.*\.json$/.test(name)))
+    const interrupted = JSON.parse(await readFile(file)), checkpoint = interrupted.appendCheckpoint
+    assert.equal(interrupted.finalizing, true)
+    assert.deepEqual([checkpoint.sessions, checkpoint.superseded, checkpoint.taskTransfers], [1, 1, 1])
+    assert.equal(interrupted.taskTransfers.length, 2)
+    const targetBefore = await readFile(targetFile), firstRecord = await readFile(path.join(h.dir('T'), `local_${sessions[0]}.json`))
+    assert.deepEqual(JSON.parse(targetBefore).scheduledTasks, [tasks[0]])
+    assert.deepEqual(JSON.parse(await readFile(sourceFile)).scheduledTasks, [])
+    let rows = mode === 'approved restart' ? [desktopFixture()[0]] : []
+    const calls = [], io = { inspect: () => rows, command: async name => {
+      calls.push(name)
+      rows = name.endsWith('osascript') ? [] : [{ ...desktopFixture()[0], pid: 700, desktopPid: 700, started: 'reopened' }]
+      return { status: 0 }
+    } }
+    const planned = mode === 'approved restart' ? await finishWorkflow(h.paths, { io }) : null
+    if (planned) assert.equal(planned.plan.kind, 'recover')
+    const options = { io, processes: [], ...(planned ? { approve: planned.plan.token } : {}) }
+    const planFile = path.join(h.paths.state, 'restart-plan.json'), planBefore = await readFile(planFile).catch(() => null)
+    if (scenario !== 'valid checkpoint') {
+      await writeFile(file, JSON.stringify({ ...interrupted, appendCheckpoint: { ...checkpoint, ...patch } }))
+      const before = await fixtureSnapshot(h), writes = []
+      const originals = new Map(['writeFile', 'appendFile', 'open', 'rename', 'link', 'unlink', 'rm'].map(key => [key, fs[key]]))
+      for (const [key, original] of originals) fs[key] = async (...args) => { writes.push(key); return original(...args) }
+      syncBuiltinESMExports()
+      try {
+        await assert.rejects(finishWorkflow(h.paths, options), /invalid append checkpoint/)
+        await assert.rejects(planned
+          ? executeMove(null, null, h.paths, { ...options, recover: true, receiptFile: file })
+          : finishPending(h.paths, options), /invalid append checkpoint/)
+      } finally {
+        for (const [key, original] of originals) fs[key] = original
+        syncBuiltinESMExports()
+      }
+      assert.deepEqual(writes, [])
+      assert.deepEqual(calls, [])
+      assert.deepEqual(await fixtureSnapshot(h), before)
+      assert.deepEqual(await readFile(planFile).catch(() => null), planBefore)
+      const retained = JSON.parse(await readFile(file))
+      assert.equal(retained.finalizing, true)
+      assert.equal(retained.taskTransfers.length, 2)
+      retained.appendCheckpoint = checkpoint
+      await writeFile(file, JSON.stringify(retained))
+    }
+    const recovered = await finishWorkflow(h.paths, options)
+    assert.equal(recovered.recoveryRequired, true)
+    assert.deepEqual(calls, planned ? ['/usr/bin/osascript', '/usr/bin/open'] : [])
+    if (planned) assert.equal(recovered.restarted, true)
+    const receipt = JSON.parse(await readFile(file))
+    assert.equal(receipt.finalizing, false)
+    assert.equal(receipt.appendCheckpoint, undefined)
+    assert.deepEqual(receipt.sessions.map(row => row.id), [sessions[0]])
+    assert.equal(receipt.superseded.length, 1)
+    assert.equal(receipt.taskTransfers.length, 1)
+    assert.deepEqual(await readFile(targetFile), targetBefore)
+    assert.deepEqual(JSON.parse(await readFile(sourceFile)), { scheduledTasks: [tasks[1]],
+      recordedSkips: { task_2: sourceRegistry.recordedSkips.task_2 }, runRetries: { task_2: sourceRegistry.runRetries.task_2 } })
+    assert.deepEqual(await readFile(path.join(h.dir('T'), `local_${sessions[0]}.json`)), firstRecord)
+    assert.deepEqual(await readFile(path.join(h.dir('P'), `local_${sessions[1]}.json`)), originalRecords[1])
+    assert.equal(await stat(path.join(h.dir('P'), `local_${sessions[0]}.json`)).catch(() => null), null)
+    assert.equal(await stat(path.join(h.dir('T'), `local_${sessions[1]}.json`)).catch(() => null), null)
+    assert.ok((await undo(h.paths, { processes: [] })).dest)
+    assert.deepEqual(JSON.parse(await readFile(sourceFile)), sourceRegistry)
+    assert.deepEqual(await Promise.all(sessions.map(sid => readFile(path.join(h.dir('P'), `local_${sid}.json`)))), originalRecords)
+    assert.equal(await stat(targetFile).catch(() => null), null)
+  })
+})
+
+test('task checkpoint integrity keeps interrupted Undo scoped to the whole receipt', async () => {
+  const h = await taskCheckpointFixture(), all = await accounts(h.paths, [])
+  const moved = await executeMove([all.find(row => row.account === h.acct.P)], all.find(row => row.account === h.acct.T), h.paths, { processes: [] })
+  assert.equal(moved.ok, true)
+  assert.equal(moved.receipt.taskTransfers.length, 2)
+  await interruptTaskFamily(h, 'undo', 'target')
+  const receipt = JSON.parse(await readFile(moved.file))
+  assert.ok(receipt.undoing)
+  receipt.appendCheckpoint = { sessions: 1, superseded: 1, taskTransfers: 1, held: [] }
+  await writeFile(moved.file, JSON.stringify(receipt))
+  assert.ok((await finishWorkflow(h.paths, { processes: [] })).dest)
+  assert.deepEqual(JSON.parse(await readFile(h.sourceFile)), h.sourceRegistry)
+  assert.deepEqual(await Promise.all(h.sessions.map(sid => readFile(path.join(h.dir('P'), `local_${sid}.json`)))), h.originalRecords)
+  assert.deepEqual(JSON.parse(await readFile(h.targetFile)), { scheduledTasks: [], recordedSkips: {}, runRetries: {} })
+  assert.deepEqual(await readdir(h.dir('T')), ['scheduled-tasks.json'])
 })
 
 test('a known account without a Desktop directory receives and undoes a task family', async () => {
@@ -3965,13 +4086,17 @@ async function interruptTaskFamily(h, operation, stage) {
   const hook = stage === 'record' ? 'link' : 'rename'
   const destination = stage === 'record' ? path.join(h.dir('T'), `local_${h.notificationId ?? SOURCE}.json`) : stage === 'source' ? h.sourceFile : h.targetFile
   const script = `
+    import childProcess from 'node:child_process'
     import fs from 'node:fs/promises'
     import { syncBuiltinESMExports } from 'node:module'
     import { accounts, executeMove, layout, undo } from './transplant.js'
+    childProcess.spawnSync = (${fixtureCommand.toString()})(childProcess.spawnSync)
+    childProcess.spawn = (${fixtureCommand.toString()})(childProcess.spawn)
     const original = fs.${hook}
+    let mutations = 0
     fs.${hook} = async (...args) => {
       const result = await original(...args)
-      if (args[1] === ${JSON.stringify(destination)}) process.exit(23)
+      if (args[1] === ${JSON.stringify(destination)} && ++mutations === ${JSON.stringify(h.interruptAfter ?? 1)}) process.exit(23)
       return result
     }
     syncBuiltinESMExports()
@@ -3981,8 +4106,8 @@ async function interruptTaskFamily(h, operation, stage) {
     else await executeMove(${JSON.stringify(h.sourceAccounts ?? [h.acct.P])}.map(account => all.find(row => row.account === account)), all.find(row => row.account === ${JSON.stringify(h.acct.T)}), paths, { processes: [] })
   `
   const result = await promisify(execFile)(process.execPath, ['--input-type=module', '-e', script], { cwd: here, env: { ...process.env, HOME: h.root } })
-    .then(() => 0, error => error.code)
-  assert.equal(result, 23)
+    .then(() => ({ code: 0 }), error => error)
+  assert.equal(result.code, 23, result.stderr)
 }
 
 test('task registry and record interruptions recover in the existing receipt', async () => {

--- a/transplant.test.js
+++ b/transplant.test.js
@@ -3470,6 +3470,18 @@ async function taskFamilyFixture(enabled = false, taskCount = 2, eventCount = 1)
   return { ...h, run, second, cold, tasks, sourceRegistry, targetRegistry, sourceAfter, targetAfter, sourceFile, targetFile, selection }
 }
 
+function taskHarness(rows = [desktopFixture()[0]], reopened = [{ ...desktopFixture()[0], pid: 700, desktopPid: 700, started: 'reopened' }]) {
+  const mock = { rows, calls: [], time: 0 }
+  mock.io = { inspect: () => mock.rows, now: () => mock.time, command: async file => {
+    mock.calls.push(file)
+    mock.time += 100
+    if (file.endsWith('osascript')) await mock.beforeQuit?.()
+    mock.rows = file.endsWith('osascript') ? [] : reopened
+    return { status: 0 }
+  } }
+  return mock
+}
+
 async function fixtureSnapshot(h, directories = [h.paths.records, h.paths.pool, h.paths.state]) {
   const files = {}
   const visit = async dir => {
@@ -3541,12 +3553,7 @@ test('Undo validates every supplied approval before changing records or receipts
   for (const scenario of ['stale receipt', 'invalid', 'empty', 'wrong operation', 'consumed', 'stopped scheduler', 'pending recovery']) {
     const h = await taskFamilyFixture(), { from, to } = await h.selection()
     const moved = await executeMove([from], to, h.paths, { processes: [] })
-    let rows = [desktopFixture()[0]]
-    const calls = [], io = { inspect: () => rows, command: async file => {
-      calls.push(file)
-      rows = file.endsWith('osascript') ? [] : [{ ...desktopFixture()[0], pid: 700, desktopPid: 700, started: 'reopened' }]
-      return { status: 0 }
-    } }
+    const mock = taskHarness(), { calls, io } = mock
     const planned = await (scenario === 'wrong operation' ? executeMove(null, null, h.paths, { io }) : undo(h.paths, { io }))
     assert.ok(planned.plan, scenario)
     assert.equal(planned.plan.receiptFile, scenario === 'wrong operation' ? null : moved.file)
@@ -3563,7 +3570,7 @@ test('Undo validates every supplied approval before changing records or receipts
       receipt.finalizing = true
       await writeFile(moved.file, JSON.stringify(receipt))
     }
-    if (scenario === 'stopped scheduler') rows = []
+    if (scenario === 'stopped scheduler') mock.rows = []
     calls.length = 0
     const before = await fixtureSnapshot(h)
     const refused = await undo(h.paths, { io, approve: scenario === 'empty' ? '' : scenario === 'invalid' || scenario === 'pending recovery' ? '0'.repeat(64) : planned.plan.token })
@@ -3571,6 +3578,27 @@ test('Undo validates every supplied approval before changing records or receipts
     assert.match(refused.reason, /approval|receipt changed|Open Claude sessions changed/, scenario)
     assert.deepEqual(await fixtureSnapshot(h), before, scenario)
     assert.equal(calls.some(file => file.endsWith('osascript')), false, scenario)
+  }
+})
+
+test('task approval tokens reject empty and malformed values without file mutations through API and CLI', async () => {
+  for (const operation of ['move', 'finish', 'undo', 'restart', 'idle finish', 'held finish']) {
+    const h = await taskFamilyFixture(), { from, to } = await h.selection(), { io, calls } = taskHarness([])
+    if (operation === 'finish') await interruptTaskFamily(h, 'move', 'target')
+    if (operation === 'undo' || operation === 'held finish') await executeMove([from], to, h.paths, { processes: operation === 'undo' ? [] : desktopFixture(), moveOnly: true })
+    const command = operation === 'move' ? ['--from', 'p@example.com', '--to', 't@example.com'] : [operation.endsWith('finish') ? 'finish' : operation]
+    const before = await fixtureSnapshot(h, [h.root])
+    for (const approve of ['', 'invalid']) {
+      const options = { io, processes: [], approve }
+      const result = await (operation.endsWith('finish') ? finishWorkflow(h.paths, options) : operation === 'undo' ? undo(h.paths, options) : executeMove(operation === 'move' ? [from] : null, operation === 'move' ? to : null, h.paths, options))
+      assert.deepEqual(result, { ok: false, reason: 'Restart approval is missing or does not match the saved plan' }, operation)
+      assert.deepEqual(await fixtureSnapshot(h, [h.root]), before, operation)
+      const rejected = await cli(h.root, [...command, '--restart-approved', approve, '--json'])
+      assert.equal(rejected.code, 1, operation)
+      assert.match(rejected.stderr, /restart approval token must be the one displayed by the engine/, operation)
+      assert.deepEqual(await fixtureSnapshot(h, [h.root]), before, operation)
+      assert.deepEqual(calls, [], operation)
+    }
   }
 })
 
@@ -3628,12 +3656,7 @@ test('task recovery scopes validation, restart and accounts to the unfinished fa
     const f = await identityFixture(h)
     await writeFile(h.paths.desktop, JSON.stringify({ lastKnownAccountUuid: h.acct[active] }))
     await f.write(f.init(1, h.acct[active], h.org[active]))
-    let rows = f.processes
-    const calls = [], io = { inspect: () => rows, command: async name => {
-      calls.push(name)
-      rows = name.endsWith('osascript') ? [] : f.processes
-      return { status: 0 }
-    } }
+    const { calls, io } = taskHarness(f.processes, f.processes)
     let result = await finishWorkflow(h.paths, { io })
     if (active === 'T') {
       assert.ok(result.plan)
@@ -3683,12 +3706,7 @@ test('task checkpoint integrity refuses corruption before recovery writes or res
     const targetBefore = await readFile(targetFile), firstRecord = await readFile(path.join(h.dir('T'), `local_${sessions[0]}.json`))
     assert.deepEqual(JSON.parse(targetBefore).scheduledTasks, [tasks[0]])
     assert.deepEqual(JSON.parse(await readFile(sourceFile)).scheduledTasks, [])
-    let rows = mode === 'approved restart' ? [desktopFixture()[0]] : []
-    const calls = [], io = { inspect: () => rows, command: async name => {
-      calls.push(name)
-      rows = name.endsWith('osascript') ? [] : [{ ...desktopFixture()[0], pid: 700, desktopPid: 700, started: 'reopened' }]
-      return { status: 0 }
-    } }
+    const { calls, io } = taskHarness(mode === 'approved restart' ? [desktopFixture()[0]] : [])
     const planned = mode === 'approved restart' ? await finishWorkflow(h.paths, { io }) : null
     if (planned) assert.equal(planned.plan.kind, 'recover')
     const options = { io, processes: [], ...(planned ? { approve: planned.plan.token } : {}) }
@@ -3757,23 +3775,6 @@ test('task checkpoint integrity keeps interrupted Undo scoped to the whole recei
   assert.deepEqual(await Promise.all(h.sessions.map(sid => readFile(path.join(h.dir('P'), `local_${sid}.json`)))), h.originalRecords)
   assert.deepEqual(JSON.parse(await readFile(h.targetFile)), { scheduledTasks: [], recordedSkips: {}, runRetries: {} })
   assert.deepEqual(await readdir(h.dir('T')), ['scheduled-tasks.json'])
-})
-
-test('a known account without a Desktop directory receives and undoes a task family', async () => {
-  const h = await taskFamilyFixture()
-  await fs.rm(h.dir('T'), { recursive: true })
-  const { from, to } = await h.selection()
-  assert.deepEqual(to.sessions, [])
-  const moved = await executeMove([from], to, h.paths, { processes: [] })
-  assert.equal(moved.ok, true)
-  assert.equal(moved.receipt.sessions.length, 4)
-  assert.deepEqual(JSON.parse(await readFile(h.targetFile)), { scheduledTasks: h.tasks,
-    recordedSkips: { task_0: h.sourceRegistry.recordedSkips.task_0, task_1: h.sourceRegistry.recordedSkips.task_1 }, runRetries: { task_0: h.sourceRegistry.runRetries.task_0 } })
-  assert.deepEqual(JSON.parse(await readFile(h.sourceFile)), h.sourceAfter)
-  assert.ok((await undo(h.paths, { processes: [] })).dest)
-  assert.deepEqual(await readdir(h.dir('T')), [])
-  assert.deepEqual(JSON.parse(await readFile(h.sourceFile)), h.sourceRegistry)
-  for (const sid of [SOURCE, h.run, h.second, h.cold]) assert.ok(await readFile(path.join(h.dir('P'), `local_${sid}.json`)))
 })
 
 test('task preflight refuses absent sources and unreadable destination data', async () => {
@@ -3997,26 +3998,6 @@ test('task Undo preserves identical pre-existing selected destination state', as
   assert.deepEqual(JSON.parse(await readFile(h.sourceFile)), h.sourceRegistry)
 })
 
-test('selected source task state arriving after transfer blocks Undo and recovery', async () => {
-  for (const recovery of [false, true]) for (const key of ['recordedSkips', 'runRetries']) {
-    const h = await taskFamilyFixture(), { from, to } = await h.selection()
-    if (recovery) await interruptTaskFamily(h, 'move', 'target')
-    else await executeMove([from], to, h.paths, { processes: [] })
-    const before = await readFile(h.sourceFile), target = await readFile(h.targetFile)
-    const edited = JSON.parse(before)
-    edited[key].task_0 = key === 'recordedSkips' ? [{ at: '2026-09-09T00:00:00Z', reason: 'missed' }] : { slot: '2026-09-09T00:00:00Z', attempts: 1, notBefore: '2026-09-09T00:05:00Z' }
-    await writeFile(h.sourceFile, JSON.stringify(edited))
-    const refused = await (recovery ? finishWorkflow : undo)(h.paths, { processes: [] })
-    assert.match((refused.reconciled?.problems ?? refused.restoreProblems ?? refused.changed).join(' '), /scheduled task state changed/)
-    assert.deepEqual(JSON.parse(await readFile(h.sourceFile)), edited)
-    assert.deepEqual(await readFile(h.targetFile), target)
-    await writeFile(h.sourceFile, before)
-    const fixed = await (recovery ? finishWorkflow : undo)(h.paths, { processes: [] })
-    assert.ok(recovery ? fixed.recoveryRequired : fixed.dest)
-    assert.deepEqual(JSON.parse(await readFile(h.sourceFile)), h.sourceRegistry)
-  }
-})
-
 test('unsafe task families leave ordinary records movable', async () => {
   for (const reason of ['missing record', 'missing history', 'task collision', 'source collision', 'record collision', 'omitted member']) {
     const h = await taskFamilyFixture(), { from, to } = await h.selection()
@@ -4123,6 +4104,7 @@ test('resumed mixed ordinary and task work counts every newly placed record', as
 async function interruptTaskFamily(h, operation, stage) {
   const hook = stage === 'record' ? 'link' : 'rename'
   const destination = stage === 'record' ? path.join(h.dir('T'), `local_${h.notificationId ?? SOURCE}.json`) : stage === 'source' ? h.sourceFile : h.targetFile
+  const matches = stage === 'receipt' ? `args[1].startsWith(paths.state + '/') && JSON.parse(await fs.readFile(args[1], 'utf8')).taskTransfers?.length` : `args[1] === ${JSON.stringify(destination)}`
   const script = `
     import childProcess from 'node:child_process'
     import fs from 'node:fs/promises'
@@ -4134,7 +4116,7 @@ async function interruptTaskFamily(h, operation, stage) {
     let mutations = 0
     fs.${hook} = async (...args) => {
       const result = await original(...args)
-      if (args[1] === ${JSON.stringify(destination)} && ++mutations === ${JSON.stringify(h.interruptAfter ?? 1)}) process.exit(23)
+      if (${matches} && ++mutations === ${JSON.stringify(h.interruptAfter ?? 1)}) process.exit(23)
       return result
     }
     syncBuiltinESMExports()
@@ -4148,25 +4130,43 @@ async function interruptTaskFamily(h, operation, stage) {
   assert.equal(result.code, 23, result.stderr)
 }
 
-test('task registry and record interruptions recover in the existing receipt', async () => {
-  for (const stage of ['source', 'record', 'target']) {
-    const h = await taskFamilyFixture(true)
-    await interruptTaskFamily(h, 'move', stage)
-    const result = await finishWorkflow(h.paths, { processes: [] })
-    assert.equal(result.recoveryRequired, true)
+test('task registry and record interruptions recover moves and Undo in the existing receipt', async () => {
+  for (const [operation, stage] of [['move', 'source'], ['move', 'record'], ['move', 'target'], ['move', 'receipt'], ['undo', 'target'], ['undo', 'source']]) {
+    const h = await taskFamilyFixture(true), { from, to } = await h.selection()
+    if (operation === 'undo') await executeMove([from], to, h.paths, { processes: [] })
+    if (stage === 'receipt') await unlink(h.targetFile)
+    await interruptTaskFamily(h, operation, stage)
+    if (operation === 'undo') {
+      const pending = lines((await cli(h.root, ['accounts', '--json'])).stdout)[0].filter(row => row.pending)
+      assert.deepEqual(pending.map(row => [row.pending, row.pendingAction]), [['undo', 'finish']])
+    }
     const files = (await readdir(h.paths.state)).filter(name => /^\d.*\.json$/.test(name))
     assert.equal(files.length, 1)
-    const receipt = JSON.parse(await readFile(path.join(h.paths.state, files[0])))
-    assert.equal(receipt.finalizing, false)
-    assert.deepEqual(receipt.sessions.map(row => row.id), [h.cold])
-    assert.deepEqual(receipt.taskTransfers, [])
+    const file = path.join(h.paths.state, files[0]), interrupted = JSON.parse(await readFile(file))
+    if (stage === 'receipt') {
+      assert.equal(interrupted.finalizing, true)
+      assert.equal(interrupted.taskTransfers.length, 1)
+      assert.equal(interrupted.taskTransfers[0].targetExisted, false)
+      await assert.rejects(readFile(h.targetFile), { code: 'ENOENT' })
+      assert.deepEqual(JSON.parse(await readFile(h.sourceFile)), h.sourceRegistry)
+    }
+    const result = await finishWorkflow(h.paths, { processes: [] })
+    if (operation === 'undo') assert.ok(result.dest)
+    else {
+      assert.equal(result.recoveryRequired, true)
+      assert.deepEqual((await readdir(h.paths.state)).filter(name => /^\d.*\.json$/.test(name)), files)
+      const receipt = JSON.parse(await readFile(file))
+      assert.equal(receipt.finalizing, false)
+      assert.deepEqual(receipt.sessions.map(row => row.id), [h.cold])
+      assert.deepEqual(receipt.taskTransfers, [])
+    }
     assert.deepEqual(JSON.parse(await readFile(h.sourceFile)), h.sourceRegistry)
-    assert.deepEqual(JSON.parse(await readFile(h.targetFile)), h.targetRegistry)
+    assert.deepEqual(await readFile(h.targetFile).then(JSON.parse, error => { if (error.code === 'ENOENT') return null; throw error }), stage === 'receipt' ? null : h.targetRegistry)
     for (const sid of [SOURCE, h.run, h.second]) {
       assert.ok(await readFile(path.join(h.dir('P'), `local_${sid}.json`)))
       assert.equal(await stat(path.join(h.dir('T'), `local_${sid}.json`)).catch(() => null), null)
     }
-    assert.ok((await undo(h.paths, { processes: [] })).dest)
+    if (operation === 'move') assert.ok((await undo(h.paths, { processes: [] })).dest)
   }
 })
 
@@ -4193,12 +4193,7 @@ test('CLI accounts exposes task recovery through Finish without selecting histor
   assert.equal(pending[0].receipt, file)
   assert.deepEqual(pending[0].pendingFailures, [])
   assert.deepEqual(await readFile(file), before)
-  let rows = [desktopFixture()[0]]
-  const calls = [], io = { inspect: () => rows, command: async name => {
-    calls.push(name)
-    rows = name.endsWith('osascript') ? [] : [{ ...desktopFixture()[0], pid: 700, desktopPid: 700, started: 'reopened' }]
-    return { status: 0 }
-  } }
+  const { calls, io } = taskHarness()
   const plan = await finishWorkflow(h.paths, { io })
   assert.ok(plan.plan)
   assert.equal(plan.plan.kind, 'recover')
@@ -4221,39 +4216,29 @@ test('CLI accounts exposes task recovery through Finish without selecting histor
   assert.ok(lines((await cli(h.root, ['accounts', '--json'])).stdout)[0].every(row => row.pending === null))
 })
 
-test('interrupted task Undo restores registrations and records together', async () => {
-  for (const stage of ['target', 'source']) {
-    const h = await taskFamilyFixture(true), { from, to } = await h.selection()
-    await executeMove([from], to, h.paths, { processes: [] })
-    await interruptTaskFamily(h, 'undo', stage)
-    const pending = lines((await cli(h.root, ['accounts', '--json'])).stdout)[0].filter(row => row.pending)
-    assert.deepEqual(pending.map(row => [row.pending, row.pendingAction]), [['undo', 'finish']])
-    const result = await finishWorkflow(h.paths, { processes: [] })
-    assert.ok(result.dest)
-    assert.deepEqual(JSON.parse(await readFile(h.sourceFile)), h.sourceRegistry)
-    assert.deepEqual(JSON.parse(await readFile(h.targetFile)), h.targetRegistry)
-  }
-})
-
 test('task edits and dependencies block Undo and interrupted recovery without overwriting registries', async () => {
-  for (const recovery of [false, true]) for (const change of ['task', 'dependency', 'skip', 'retry', 'skip removed', 'retry removed', 'retry added']) {
+  for (const recovery of [false, true]) for (const change of ['task', 'dependency', 'skip', 'retry', 'skip removed', 'retry removed', 'retry added', 'source skip', 'source retry']) {
     const h = await taskFamilyFixture(), { from, to } = await h.selection()
     if (recovery) await interruptTaskFamily(h, 'move', 'target')
     else await executeMove([from], to, h.paths, { processes: [] })
-    const before = JSON.parse(await readFile(h.targetFile)), changed = structuredClone(before)
+    const source = change.startsWith('source'), file = source ? h.sourceFile : h.targetFile
+    const before = await readFile(file), target = await readFile(h.targetFile), changed = JSON.parse(before)
     if (change === 'task') changed.scheduledTasks.find(task => task.id === h.tasks[0].id).enabled = true
     else if (change === 'dependency') changed.scheduledTasks.push({ id: 'new_task', notifySessionId: `local_${SOURCE}`, enabled: false })
     else if (change === 'skip') changed.recordedSkips.task_0[0].reason = 'edited'
     else if (change === 'retry') changed.runRetries.task_0.attempts++
     else if (change === 'skip removed') delete changed.recordedSkips.task_0
     else if (change === 'retry removed') delete changed.runRetries.task_0
-    else changed.runRetries.task_1 = { slot: '2026-09-05T00:00:00Z', attempts: 1, notBefore: '2026-09-05T00:00:00Z' }
-    await writeFile(h.targetFile, JSON.stringify(changed))
+    else if (change === 'retry added') changed.runRetries.task_1 = { slot: '2026-09-05T00:00:00Z', attempts: 1, notBefore: '2026-09-05T00:00:00Z' }
+    else if (change === 'source skip') changed.recordedSkips.task_0 = [{ at: '2026-09-09T00:00:00Z', reason: 'missed' }]
+    else changed.runRetries.task_0 = { slot: '2026-09-09T00:00:00Z', attempts: 1, notBefore: '2026-09-09T00:05:00Z' }
+    await writeFile(file, JSON.stringify(changed))
     const result = await (recovery ? finishWorkflow : undo)(h.paths, { processes: [] })
-    assert.match((result.reconciled?.problems ?? result.restoreProblems ?? result.changed).join(' '), /scheduled task/)
-    assert.deepEqual(JSON.parse(await readFile(h.targetFile)), changed)
+    assert.match((result.reconciled?.problems ?? result.restoreProblems ?? result.changed).join(' '), source ? /scheduled task state changed/ : /scheduled task/)
+    assert.deepEqual(JSON.parse(await readFile(file)), changed)
+    if (source) assert.deepEqual(await readFile(h.targetFile), target)
     assert.ok(await readFile(path.join(h.dir('T'), `local_${SOURCE}.json`)))
-    await writeFile(h.targetFile, JSON.stringify(before))
+    await writeFile(file, before)
     const retried = await (recovery ? finishWorkflow : undo)(h.paths, { processes: [] })
     assert.ok(recovery ? retried.recoveryRequired : retried.dest)
     assert.deepEqual(JSON.parse(await readFile(h.sourceFile)), h.sourceRegistry)
@@ -4310,21 +4295,12 @@ test('task moves, Undo and recovery use the approved restart and preserve final 
     const h = await taskFamilyFixture(), { from, to } = await h.selection()
     if (operation === 'undo') await executeMove([from], to, h.paths, { processes: [] })
     if (operation === 'recovery') await interruptTaskFamily(h, 'move', 'target')
-    let rows = [desktopFixture()[0]], time = 0
-    const calls = []
-    const io = { inspect: () => rows, now: () => time, command: async file => {
-      calls.push(file)
-      time += 100
-      if (file.endsWith('osascript')) {
-        if (operation === 'move') {
-          h.sourceRegistry.scheduledTasks[0].lastScheduledFor = '2026-09-03T00:00:00Z'
-          h.sourceRegistry.scheduledTasks[0].enabled = true
-          await writeFile(h.sourceFile, JSON.stringify(h.sourceRegistry))
-        }
-        rows = []
-      } else rows = [{ ...desktopFixture()[0], pid: 700, desktopPid: 700, started: 'reopened' }]
-      return { status: 0 }
-    } }
+    const mock = taskHarness(), { calls, io } = mock
+    if (operation === 'move') mock.beforeQuit = async () => {
+      h.sourceRegistry.scheduledTasks[0].lastScheduledFor = '2026-09-03T00:00:00Z'
+      h.sourceRegistry.scheduledTasks[0].enabled = true
+      await writeFile(h.sourceFile, JSON.stringify(h.sourceRegistry))
+    }
     const run = options => operation === 'move' ? executeMove([from], to, h.paths, options) : operation === 'undo' ? undo(h.paths, options) : finishWorkflow(h.paths, options)
     const plan = await run({ io })
     assert.ok(plan.plan, operation)
@@ -4332,7 +4308,7 @@ test('task moves, Undo and recovery use the approved restart and preserve final 
     const result = await run({ io, approve: plan.plan.token })
     assert.equal(result.restarted, true, JSON.stringify({ operation, reason: result.reason, outcome: result.restartOutcome?.outcome }))
     assert.deepEqual(calls, ['/usr/bin/osascript', '/usr/bin/open'])
-    assert.ok(time < 30000)
+    assert.ok(mock.time < 30000)
     if (operation === 'move') {
       assert.equal(result.ok, true)
       assert.deepEqual(JSON.parse(await readFile(h.targetFile)).scheduledTasks.slice(1), h.sourceRegistry.scheduledTasks)
@@ -4363,18 +4339,14 @@ test('task workers and changed restart inventories never authorize an external s
 
 test('task restart deadline preserves held families after completed ordinary work', async () => {
   const h = await taskFamilyFixture(), { from, to } = await h.selection()
-  let rows = [desktopFixture()[0]], time = 0
-  const io = { inspect: () => rows, now: () => time, command: async file => {
-    rows = file.endsWith('osascript') ? [] : [{ ...desktopFixture()[0], pid: 700, desktopPid: 700, started: 'reopened' }]
-    return { status: 0 }
-  } }
+  const mock = taskHarness(), { io } = mock
   const planned = await executeMove([from], to, h.paths, { io })
   const original = fs.rename
   fs.rename = async (...args) => {
     const result = await original(...args)
     if (path.dirname(args[1]) === h.paths.state && /^\d.*\.json$/.test(path.basename(args[1]))) {
       const receipt = JSON.parse(await readFile(args[1]))
-      if (receipt.finalizing === false && receipt.sessions.length === 1) time = 23000
+      if (receipt.finalizing === false && receipt.sessions.length === 1) mock.time = 23000
     }
     return result
   }
@@ -4553,16 +4525,43 @@ test('task scheduler safety uses the exact organization and rechecks account swi
   }
 })
 
-test('task Undo preserves absent registries and registries without a task array', async () => {
-  for (const registry of [null, { future: { intact: true } }]) {
-    const h = await taskFamilyFixture()
+test('task Undo preserves absent directories and registries and only tolerates ENOENT on removal', async () => {
+  for (const scenario of ['directory', 'registry', 'fields', 'ENOENT', 'EACCES']) {
+    const h = await taskFamilyFixture(), registry = scenario === 'fields' ? { future: { intact: true } } : null
     if (registry) await writeFile(h.targetFile, JSON.stringify(registry))
+    else if (scenario === 'directory') await fs.rm(h.dir('T'), { recursive: true })
     else await unlink(h.targetFile)
     const { from, to } = await h.selection()
-    const result = await executeMove([from], to, h.paths, { processes: [] })
-    assert.equal(result.ok, true)
-    assert.ok((await undo(h.paths, { processes: [] })).dest)
-    assert.deepEqual(await readFile(h.targetFile).then(JSON.parse, () => null), registry)
+    assert.deepEqual(to.sessions, [])
+    const moved = await executeMove([from], to, h.paths, { processes: [] })
+    assert.equal(moved.ok, true)
+    assert.equal(moved.receipt.sessions.length, 4)
+    const target = await readFile(h.targetFile), original = fs.unlink
+    assert.deepEqual(JSON.parse(target), { ...registry, scheduledTasks: h.tasks,
+      recordedSkips: { task_0: h.sourceRegistry.recordedSkips.task_0, task_1: h.sourceRegistry.recordedSkips.task_1 }, runRetries: { task_0: h.sourceRegistry.runRetries.task_0 } })
+    assert.deepEqual(JSON.parse(await readFile(h.sourceFile)), h.sourceAfter)
+    let removals = 0, undone
+    fs.unlink = async (...args) => {
+      if (args[0] !== h.targetFile || !scenario.startsWith('E')) return original(...args)
+      removals++
+      if (scenario === 'ENOENT') await original(...args)
+      throw Object.assign(new Error('fixture registry removal failure'), { code: scenario })
+    }
+    syncBuiltinESMExports()
+    try {
+      if (scenario === 'EACCES') await assert.rejects(undo(h.paths, { processes: [] }), { code: scenario, message: 'fixture registry removal failure' })
+      else undone = await undo(h.paths, { processes: [] })
+    } finally { fs.unlink = original; syncBuiltinESMExports() }
+    if (scenario.startsWith('E')) assert.equal(removals, 1)
+    if (scenario === 'EACCES') {
+      assert.deepEqual(await readFile(h.targetFile), target)
+      undone = await finishWorkflow(h.paths, { processes: [] })
+    }
+    assert.ok(undone.dest)
+    assert.deepEqual(await readdir(h.dir('T')), registry ? ['scheduled-tasks.json'] : [])
+    assert.deepEqual(await readFile(h.targetFile).then(JSON.parse, error => { if (error.code === 'ENOENT') return null; throw error }), registry)
+    assert.deepEqual(JSON.parse(await readFile(h.sourceFile)), h.sourceRegistry)
+    for (const sid of [SOURCE, h.run, h.second, h.cold]) assert.ok(await readFile(path.join(h.dir('P'), `local_${sid}.json`)))
   }
 })
 

--- a/transplant.test.js
+++ b/transplant.test.js
@@ -1023,8 +1023,9 @@ test('idle Finish reports refused sessions quietly while verification errors rem
   assert.match(text.stdout, /nothing pending\n.*not moved.*conflicting duplicate uuids/s)
   const refused = lines((await cli(h.root, ['sweep', '--json'])).stdout)[0]
   assert.equal(refused.receipt, moved.file)
-  assert.equal(refused.complete, false)
-  assert.equal(refused.failed.length, 1)
+  assert.equal(refused.complete, true)
+  assert.equal(refused.failed.length, 0)
+  assert.equal(refused.notMoved.length, 1)
   const receipt = JSON.parse(await readFile(moved.file, 'utf8'))
   receipt.failed = []
   await writeFile(moved.file, JSON.stringify(receipt))
@@ -1291,7 +1292,9 @@ test('an unreadable scheduled task registry fails closed', async () => {
   let by = Object.fromEntries((await accounts(h.paths)).map((a) => [a.account, a]))
   assert.match(by[h.acct.P].taskError, /invalid scheduled task registry/)
   assert.match(by[h.acct.P].stats, /task registry unreadable/)
-  await assert.rejects(inventory([by[h.acct.P]], by[h.acct.Z], h.paths), /invalid scheduled task registry/)
+  const blocked = await inventory([by[h.acct.P]], by[h.acct.Z], h.paths)
+  assert.equal(blocked.move.length, 0)
+  assert.match(blocked.blocked[0].error, /invalid scheduled task registry/)
   await writeFile(taskFile, JSON.stringify({ scheduledTasks: [] }))
   by = Object.fromEntries((await accounts(h.paths)).map((a) => [a.account, a]))
   const inv = await inventory([by[h.acct.P]], by[h.acct.Z], h.paths)
@@ -1996,7 +1999,7 @@ test('a refused retirement restores the source cloud check', async () => {
   const from = all.find((account) => account.account === h.acct.T && account.org === h.org.T)
   const to = all.find((account) => account.account === h.acct.Z && account.org === h.org.Z)
   const inv = await inventory([from], to, h.paths, () => {}, { cloudRequested: true })
-  assert.equal(inv.cloudCheckAccounts.length, 0)
+  assert.equal(inv.cloudCheckAccounts.length, 1)
   const result = await move(inv, to, h.paths)
 
   assert.equal(result.pendingCloud, 1)
@@ -2050,6 +2053,50 @@ test('Keep local accepts a valid rehome record used after the move', async () =>
   assert.equal(kept.cancelled, 1)
 })
 
+test('Keep local tolerates independent Desktop metadata and destination bridges', async () => {
+  for (const extra of [
+    { bridgeSessionIds: ['session_destination'] },
+    { toolSurfaceSnapshot: { familyHashes: { builtin: 'changed' }, recordedAt: 123 } },
+    { bridgeSessionIds: ['session_destination'], toolSurfaceSnapshot: { recordedAt: 456 } },
+    { lastActivityAt: 999, completedTurns: 8, futureMetadata: { display: true } }
+  ]) {
+    const h = await home()
+    await h.write(SOURCE, [entry('user', 1, null, SOURCE)])
+    await h.record('T', SOURCE, rehomeRecord())
+    const all = await accounts(h.paths), from = all.find(row => row.account === h.acct.T), to = all.find(row => row.account === h.acct.Z)
+    const moved = await moveWithPending(h, [from], to)
+    const row = moved.receipt.sessions[0]
+    await writeFile(row.record, JSON.stringify({ ...JSON.parse(await readFile(row.record)), ...extra }))
+    const kept = await keepLocal(h.paths)
+    assert.equal(kept.ok, true)
+    assert.equal(kept.cancelled, 1)
+    assert.deepEqual(JSON.parse(await readFile(row.record)).bridgeSessionIds, extra.bridgeSessionIds ?? [])
+    if (extra.bridgeSessionIds) assert.match((await undo(h.paths)).changed[0], /desktop record/)
+  }
+})
+
+test('Finish cloud success retains historical local refusals as information', async () => {
+  for (const failure of ['none', 'verification', 'verification without details', 'cloud']) {
+    const h = await home()
+    await h.write(SOURCE, [entry('user', 1, null, SOURCE)])
+    await h.record('T', SOURCE, rehomeRecord())
+    const all = await accounts(h.paths), from = all.find(row => row.account === h.acct.T), to = all.find(row => row.account === h.acct.Z)
+    const moved = await moveWithPending(h, [from], to)
+    const receipt = JSON.parse(await readFile(moved.file))
+    receipt.failed.push({ id: id(998), title: 'Unmoved task', error: 'scheduled task family missing' })
+    if (failure.startsWith('verification')) receipt.verification = { ok: false, problems: failure === 'verification' ? [{ id: SOURCE, check: 'transcript' }] : [] }
+    await writeFile(moved.file, JSON.stringify(receipt))
+    const cloud = cloudFixture(h, { account: from.account, org: from.org,
+      list: async () => { if (failure === 'cloud') throw new Error('fixture offline'); return [] } })
+    const result = await finishPending(h.paths, { cloud })
+    assert.equal(result.ok, failure === 'none')
+    assert.equal(result.complete, failure !== 'cloud')
+    assert.equal(result.receipt.failed.some(row => row.title === 'Unmoved task'), true)
+    assert.equal(result.failed.length, failure === 'cloud' ? 1 : 0)
+    if (failure !== 'cloud') assert.equal((await cli(h.root, ['finish', '--json'])).code, failure === 'none' ? 0 : 1)
+  }
+})
+
 test('Keep local refuses structural rehome record drift', async () => {
   const h = await home()
   await h.write(SOURCE, [entry('user', 1, null, SOURCE)])
@@ -2075,7 +2122,7 @@ test('Keep local keeps strict validation for older receipts', async () => {
   const to = all.find((account) => account.account === h.acct.Z && account.org === h.org.Z)
   const moved = await moveWithPending(h, [from], to)
   const receipt = JSON.parse(await readFile(moved.file, 'utf8'))
-  delete receipt.sessions[0].recordKeepSemantic
+  delete receipt.sessions[0].recordSnapshot
   await writeFile(moved.file, JSON.stringify(receipt))
   const record = path.join(h.dir('Z'), `local_${SOURCE}.json`)
   await writeFile(record, JSON.stringify({ ...JSON.parse(await readFile(record)), cwd: '/tmp/changed' }))
@@ -3368,6 +3415,756 @@ test('an interrupted unapplied archive leaves a tagged failure that retry clears
   assert.equal(status, 'archived')
 })
 
+async function taskFamilyFixture(enabled = false, taskCount = 2, eventCount = 1) {
+  const h = await home(), run = id(701), second = id(702), cold = id(703)
+  const runs = [run, second].slice(0, taskCount)
+  const tasks = runs.map((sid, index) => ({ id: `task_${index}`, notifySessionId: `local_${SOURCE}`,
+    enabled, fireAt: 123456 + index, filePath: path.join(h.root, '.claude', 'scheduled-tasks', `task_${index}`, 'SKILL.md'), createdAt: 123,
+    lastRunAt: '2026-09-01T00:00:00Z', lastScheduledFor: '2026-09-01T00:00:00Z' }))
+  for (const task of tasks) {
+    await mkdir(path.dirname(task.filePath), { recursive: true })
+    await writeFile(task.filePath, `---\nname: ${task.id}\n---\nSynthetic reminder prompt\n`)
+  }
+  for (const [index, sid] of [SOURCE, ...runs, cold].entries()) {
+    await h.write(sid, branchEntries(eventCount, sid, 80 + index * eventCount))
+    await h.record('P', sid, rehomeRecord(runs.includes(sid) ? { scheduledTaskId: tasks[index - 1].id, notifySessionId: `local_${SOURCE}` } : {}))
+  }
+  const skips = Object.fromEntries(tasks.map(task => [task.id, { scheduledFor: '2026-09-02T00:00:00Z', reason: 'app_closed' }]))
+  const retries = { task_0: { attempt: 2, retryAt: '2026-09-02T00:05:00Z', scheduledFor: '2026-09-02T00:00:00Z' } }
+  const unrelatedSkips = { unrelated_task: { scheduledFor: '2026-09-01T01:00:00Z', reason: 'missed' } }
+  const unrelatedRetries = { unrelated_task: { attempt: 1, retryAt: '2026-09-01T01:05:00Z' } }
+  const sourceRegistry = { scheduledTasks: tasks, recordedSkips: { ...skips, ...unrelatedSkips }, runRetries: { ...retries, ...unrelatedRetries }, sundayAliasBoundaryStamped: true,
+    dayFieldsOrBoundaryStamped: false, future: { preserved: 'source' } }
+  const targetRegistry = { scheduledTasks: [{ id: 'unrelated_task', enabled: true, cronExpression: '0 0 * * *', filePath: '/tmp/fixture/other.md' }],
+    recordedSkips: { other_task: { scheduledFor: '2026-09-03T00:00:00Z', reason: 'disabled' } }, runRetries: { other_task: { attempt: 3, retryAt: '2026-09-03T00:10:00Z' } }, future: { preserved: 'target' } }
+  const sourceAfter = { ...sourceRegistry, scheduledTasks: [], recordedSkips: unrelatedSkips, runRetries: unrelatedRetries }
+  const targetAfter = { ...targetRegistry, scheduledTasks: [...targetRegistry.scheduledTasks, ...tasks], recordedSkips: { ...targetRegistry.recordedSkips, ...skips }, runRetries: { ...targetRegistry.runRetries, ...retries } }
+  const sourceFile = path.join(h.dir('P'), 'scheduled-tasks.json'), targetFile = path.join(h.dir('T'), 'scheduled-tasks.json')
+  await writeFile(sourceFile, JSON.stringify(sourceRegistry))
+  await writeFile(targetFile, JSON.stringify(targetRegistry))
+  const selection = async () => {
+    const all = await accounts(h.paths, [])
+    return { from: all.find(row => row.account === h.acct.P), to: all.find(row => row.account === h.acct.T) }
+  }
+  return { ...h, run, second, cold, tasks, sourceRegistry, targetRegistry, sourceAfter, targetAfter, sourceFile, targetFile, selection }
+}
+
+test('task families preserve registration state, generated records and registry fields through Undo', async () => {
+  for (const enabled of [false, true]) {
+    const h = await taskFamilyFixture(enabled), { from, to } = await h.selection()
+    const prompts = await Promise.all(h.tasks.map(task => readFile(task.filePath)))
+    const inv = await inventory([from], to, h.paths, () => {}, { processes: [] })
+    assert.equal(inv.move.length, 4)
+    const moved = await executeMove([from], to, h.paths, { processes: [] })
+    assert.equal(moved.ok, true)
+    assert.equal(moved.receipt.sessions.length, 4)
+    assert.deepEqual(JSON.parse(await readFile(h.sourceFile)), h.sourceAfter)
+    assert.deepEqual(JSON.parse(await readFile(h.targetFile)), h.targetAfter)
+    assert.deepEqual(await Promise.all(h.tasks.map(task => readFile(task.filePath))), prompts)
+    assert.deepEqual(moved.receipt.taskTransfers[0].state, { recordedSkips: { task_0: h.sourceRegistry.recordedSkips.task_0, task_1: h.sourceRegistry.recordedSkips.task_1 }, runRetries: { task_0: h.sourceRegistry.runRetries.task_0 } })
+    for (const sid of [SOURCE, h.run, h.second]) {
+      const record = JSON.parse(await readFile(path.join(h.dir('T'), `local_${sid}.json`)))
+      assert.equal(record.cliSessionId, sid)
+      assert.equal(record.sessionId, `local_${sid}`)
+      if (sid !== SOURCE) assert.equal(record.notifySessionId, `local_${SOURCE}`)
+    }
+    const undone = await undo(h.paths, { processes: [] })
+    assert.ok(undone.dest)
+    assert.deepEqual(JSON.parse(await readFile(h.sourceFile)), h.sourceRegistry)
+    assert.deepEqual(JSON.parse(await readFile(h.targetFile)), h.targetRegistry)
+    assert.deepEqual(await Promise.all(h.tasks.map(task => readFile(task.filePath))), prompts)
+    for (const sid of [SOURCE, h.run, h.second, h.cold]) assert.ok(await readFile(path.join(h.dir('P'), `local_${sid}.json`)))
+  }
+})
+
+test('task family cloud work follows all local placements and reports the entire operation', async () => {
+  for (const scenario of ['match', 'rescue', 'remote changed', 'family refused']) {
+    const h = await taskFamilyFixture(false, 1, 8), { from, to } = await h.selection()
+    const anchor = scenario === 'rescue' ? h.cold : SOURCE
+    const base = lines(await readFile(path.join(h.project, `${anchor}.jsonl`), 'utf8'))
+    const remote = scenario === 'rescue' ? [...base, entry('assistant', 300, 87, 'cse_task_family')] : base
+    let status = 'active', archived = 0, changed = false
+    const reports = []
+    const cloud = cloudFixture(h, {
+      list: async () => [remoteSession({ id: 'cse_task_family', title: `Session ${anchor.slice(-3)}`, status })],
+      eventRows: async () => remoteRows(changed ? [...remote, entry('user', 301, 87, 'cse_task_family')] : remote),
+      session: async () => remoteState(status),
+      archive: async () => {
+        assert.deepEqual(JSON.parse(await readFile(h.targetFile)), h.targetAfter)
+        for (const sid of [SOURCE, h.run, h.cold]) {
+          assert.ok(await readFile(path.join(h.dir('T'), `local_${sid}.json`)))
+          assert.equal(await stat(path.join(h.dir('P'), `local_${sid}.json`)).catch(() => null), null)
+        }
+        archived++
+        status = 'archived'
+      }
+    })
+    const inv = await inventory([from], to, h.paths, () => {}, { processes: [], cloud })
+    assert.equal(inv.move.length, 3)
+    assert.equal(inv.cloud.matches.length, 1)
+    assert.deepEqual(inv.cloud.blocked, [])
+    if (scenario === 'remote changed') changed = true
+    if (scenario === 'family refused') await writeFile(h.sourceFile, JSON.stringify({ ...h.sourceRegistry, scheduledTasks: [{ ...h.tasks[0], notifySessionId: `local_${id(799)}` }] }))
+    const moved = await move(inv, to, h.paths, (stage, text, extra) => reports.push({ stage, text, ...extra }))
+    assert.equal((await readdir(h.paths.state)).filter(name => /^\d.*\.json$/.test(name)).length, 1)
+    const succeeds = ['match', 'rescue'].includes(scenario)
+    assert.equal(moved.ok, succeeds, scenario)
+    assert.equal(archived, succeeds ? 1 : 0, scenario)
+    assert.equal(moved.pendingCloud, succeeds ? 0 : 1, scenario)
+    assert.equal(moved.receipt.sessions.length, scenario === 'family refused' ? 1 : scenario === 'rescue' ? 4 : 3, scenario)
+    if (succeeds) {
+      const moves = reports.filter(row => row.stage === 'move' && !row.live)
+      assert.equal(moves.length, 1)
+      assert.match(moves[0].text, scenario === 'rescue' ? /4 ✓ \| 33 events/ : /3 ✓ \| 24 events/)
+      for (const stage of ['move', 'verify', 'retire']) {
+        const progress = reports.filter(row => row.stage === stage && row.completed !== undefined)
+        const total = stage === 'retire' ? 3 : moved.receipt.sessions.length
+        assert.ok(progress.length, stage)
+        assert.ok(progress.every((row, index) => row.total === total && row.completed >= (progress[index - 1]?.completed ?? 0)), stage)
+        assert.equal(progress.at(-1).completed, total, stage)
+      }
+    } else {
+      assert.ok(moved.receipt.failed.some(row => row.cloudAccount === h.acct.P))
+      assert.match(moved.receipt.failed.map(row => row.error).join(' '), scenario === 'family refused' ? /changed since inventory/ : /Remote Control history changed/)
+      if (scenario === 'family refused') assert.ok(await readFile(path.join(h.dir('P'), `local_${SOURCE}.json`)))
+    }
+  }
+})
+
+test('task family preflight errors cannot modify an earlier completed receipt', async () => {
+  const h = await taskFamilyFixture(), { from, to } = await h.selection()
+  const ordinary = { ...from, sessions: from.sessions.filter(row => row.id === h.cold) }
+  const first = await executeMove([ordinary], to, h.paths, { processes: [] })
+  const before = await readFile(first.file)
+  const fresh = await h.selection()
+  const inv = await inventory([fresh.from], fresh.to, h.paths, () => {}, { processes: [] })
+  h.sourceRegistry.scheduledTasks[0].notifySessionId = `local_${h.cold}`
+  await writeFile(h.sourceFile, JSON.stringify(h.sourceRegistry))
+  const result = await move(inv, fresh.to, h.paths)
+  assert.equal(result.ok, false)
+  assert.notEqual(result.file, first.file)
+  assert.deepEqual(await readFile(first.file), before)
+  assert.equal(result.receipt.sessions.length, 0)
+  assert.equal(result.added ?? 0, 0)
+  assert.equal(result.targetChanged ?? false, false)
+  assert.match(result.receipt.failed.map(row => row.error).join(' '), /changed since inventory/)
+})
+
+test('task state conflicts preserve pre-existing destination entries before and after planning', async () => {
+  for (const key of ['recordedSkips', 'runRetries']) for (const late of [false, true]) {
+    const h = await taskFamilyFixture(), { from, to } = await h.selection()
+    const planned = late ? await inventory([from], to, h.paths, () => {}, { processes: [] }) : null
+    const conflict = { ...h.targetRegistry, [key]: { ...h.targetRegistry[key], task_0: { conflict: true } } }
+    await writeFile(h.targetFile, JSON.stringify(conflict))
+    const fresh = await h.selection()
+    const result = await move(planned ?? await inventory([fresh.from], fresh.to, h.paths, () => {}, { processes: [] }), fresh.to, h.paths)
+    assert.equal(result.ok, false)
+    assert.deepEqual(result.receipt.sessions.map(row => row.id), [h.cold])
+    assert.match(result.receipt.failed.map(row => row.error).join(' '), /task state collision/)
+    assert.deepEqual(JSON.parse(await readFile(h.targetFile)), conflict)
+    assert.deepEqual(JSON.parse(await readFile(h.sourceFile)), h.sourceRegistry)
+  }
+})
+
+test('task Undo preserves identical pre-existing selected destination state', async () => {
+  const h = await taskFamilyFixture(), { from, to } = await h.selection()
+  const target = { ...h.targetRegistry, recordedSkips: { ...h.targetRegistry.recordedSkips, task_0: h.sourceRegistry.recordedSkips.task_0 } }
+  await writeFile(h.targetFile, JSON.stringify(target))
+  const moved = await executeMove([from], to, h.paths, { processes: [] })
+  assert.equal(moved.ok, true)
+  assert.ok((await undo(h.paths, { processes: [] })).dest)
+  assert.deepEqual(JSON.parse(await readFile(h.targetFile)), target)
+  assert.deepEqual(JSON.parse(await readFile(h.sourceFile)), h.sourceRegistry)
+})
+
+test('selected source task state arriving after transfer blocks Undo and recovery', async () => {
+  for (const recovery of [false, true]) for (const key of ['recordedSkips', 'runRetries']) {
+    const h = await taskFamilyFixture(), { from, to } = await h.selection()
+    if (recovery) await interruptTaskFamily(h, 'move', 'target')
+    else await executeMove([from], to, h.paths, { processes: [] })
+    const before = await readFile(h.sourceFile), target = await readFile(h.targetFile)
+    const edited = JSON.parse(before)
+    edited[key].task_0 = { scheduledFor: '2026-09-09T00:00:00Z', retryAt: '2026-09-09T00:05:00Z' }
+    await writeFile(h.sourceFile, JSON.stringify(edited))
+    const refused = await (recovery ? finishWorkflow : undo)(h.paths, { processes: [] })
+    assert.match((refused.reconciled?.problems ?? refused.restoreProblems ?? refused.changed).join(' '), /scheduled task state changed/)
+    assert.deepEqual(JSON.parse(await readFile(h.sourceFile)), edited)
+    assert.deepEqual(await readFile(h.targetFile), target)
+    await writeFile(h.sourceFile, before)
+    const fixed = await (recovery ? finishWorkflow : undo)(h.paths, { processes: [] })
+    assert.ok(recovery ? fixed.recoveryRequired : fixed.dest)
+    assert.deepEqual(JSON.parse(await readFile(h.sourceFile)), h.sourceRegistry)
+  }
+})
+
+test('unsafe task families leave ordinary records movable', async () => {
+  for (const reason of ['missing record', 'missing history', 'task collision', 'source collision', 'record collision', 'omitted member']) {
+    const h = await taskFamilyFixture(), { from, to } = await h.selection()
+    if (reason === 'missing record') await unlink(path.join(h.dir('P'), `local_${SOURCE}.json`))
+    if (reason === 'missing history') await unlink(path.join(h.project, `${h.run}.jsonl`))
+    if (reason === 'task collision') await writeFile(h.targetFile, JSON.stringify({ ...h.targetRegistry, scheduledTasks: [...h.targetRegistry.scheduledTasks, h.tasks[0]] }))
+    if (reason === 'source collision') {
+      await h.record('Q', h.run, rehomeRecord({ scheduledTaskId: h.tasks[0].id }))
+      await writeFile(path.join(h.dir('Q'), 'scheduled-tasks.json'), JSON.stringify({ scheduledTasks: [h.tasks[0]] }))
+    }
+    if (reason === 'record collision') await h.record('T', h.run, rehomeRecord({ scheduledTaskId: h.tasks[0].id }))
+    const fresh = await h.selection()
+    if (reason === 'omitted member') fresh.from.sessions = fresh.from.sessions.filter(row => row.id !== h.run)
+    const sources = [fresh.from]
+    if (reason === 'source collision') sources.push((await accounts(h.paths)).find(row => row.account === h.acct.Q))
+    const inv = await inventory(sources, fresh.to, h.paths, () => {}, { processes: [] })
+    assert.deepEqual(inv.move.map(row => row.id), [h.cold], reason)
+    const moved = await move(inv, fresh.to, h.paths)
+    assert.equal(moved.receipt.sessions.length, 1, reason)
+    assert.deepEqual(JSON.parse(await readFile(h.sourceFile)), h.sourceRegistry)
+  }
+})
+
+test('task schedulers require an explicit restart for active or unknown namespaces', async () => {
+  for (const identity of ['active', 'unknown', 'inactive']) {
+    const h = await taskFamilyFixture(), f = await identityFixture(h)
+    if (identity === 'unknown') await f.write(f.event(1, '[LocalSessionManager] Org changed'))
+    if (identity === 'inactive') {
+      await writeFile(h.paths.desktop, JSON.stringify({ lastKnownAccountUuid: h.acct.Z }))
+      await f.write(f.init(1, h.acct.Z, h.org.Z))
+    }
+    const { from, to } = await h.selection()
+    const result = await executeMove([from], to, h.paths, { processes: f.processes })
+    if (identity === 'inactive') assert.equal(result.receipt.sessions.length, 4)
+    else {
+      assert.ok(result.plan)
+      assert.equal(new Set(result.plan.held.flatMap(row => row.sources.map(source => source.id))).size, 3)
+      assert.deepEqual(JSON.parse(await readFile(h.sourceFile)), h.sourceRegistry)
+      const partial = await executeMove([from], to, h.paths, { processes: f.processes, moveOnly: true })
+      assert.equal(partial.receipt.sessions.length, 1)
+      assert.equal(partial.complete, false)
+      const background = await sweep(h.paths, { processes: f.processes })
+      assert.equal(background.result.pendingLocal, true)
+      const completed = await finishHeld(h.paths, { processes: [] })
+      assert.equal(completed.receipt.sessions.length, 4)
+      assert.equal(completed.complete, true)
+    }
+  }
+})
+
+test('a Desktop worker holds the entire task family in the exact source namespace', async () => {
+  for (const sameLogin of [false, true]) {
+    const h = await taskFamilyFixture(false, 1), f = await identityFixture(h), other = id(704)
+    if (sameLogin) { h.acct.Q = h.acct.P; await mkdir(h.dir('Q'), { recursive: true }) }
+    await writeFile(h.paths.desktop, JSON.stringify({ lastKnownAccountUuid: h.acct.Z }))
+    await f.write(f.init(1, h.acct.Z, h.org.Z))
+    await h.write(other, branchEntries(1, other, 400))
+    await h.record('Q', other, rehomeRecord({ notifySessionId: `local_${SOURCE}` }))
+    const all = await accounts(h.paths, f.processes)
+    const from = all.filter(row => [h.org.P, h.org.Q].includes(row.org)), to = all.find(row => row.account === h.acct.T)
+    const rows = [{ ...f.processes[0], desktopPid: 500 }, desktopFixture()[1]]
+    const inv = await inventory(from, to, h.paths, () => {}, { processes: rows })
+    assert.ok(inv.sources.filter(row => row.account.org === h.org.P).every(row => !row.schedulerBusy))
+    const plan = await restartPlan(inv, h.paths, rows)
+    assert.deepEqual(new Set(plan.held.flatMap(row => row.sources.map(source => source.id))), new Set([SOURCE, h.run]))
+    assert.ok(plan.held.every(row => row.sources.every(source => source.account === h.acct.P && source.org === h.org.P)))
+    const partial = await executeMove(from, to, h.paths, { processes: rows, moveOnly: true })
+    assert.deepEqual(partial.receipt.sessions.map(row => row.id), [h.cold])
+    assert.equal(partial.receipt.failed.length, 1)
+    assert.equal(partial.receipt.failed[0].id, other)
+    assert.ok(!partial.receipt.failed.some(row => [SOURCE, h.run].includes(row.id)))
+    assert.equal(new Set(partial.receipt.failed.map(row => JSON.stringify(row))).size, partial.receipt.failed.length)
+    const finished = await finishHeld(h.paths, { processes: f.processes })
+    assert.equal(finished.ok, true)
+    assert.equal(finished.complete, true)
+    assert.equal(finished.receipt.sessions.length, 3)
+    assert.equal(finished.added, 2)
+    assert.equal(finished.targetChanged, true)
+    assert.equal(finished.file, partial.file)
+    assert.equal(finished.notMoved.length, 1)
+    assert.deepEqual(finished.failed, [])
+    assert.deepEqual(JSON.parse(await readFile(h.targetFile)), h.targetAfter)
+    assert.ok(await readFile(path.join(h.dir('Q'), `local_${other}.json`)))
+  }
+})
+
+test('resumed mixed ordinary and task work counts every newly placed record', async () => {
+  const h = await taskFamilyFixture(), { from, to } = await h.selection(), firstId = id(705)
+  await h.write(firstId, branchEntries(1, firstId, 405))
+  await h.record('P', firstId, rehomeRecord())
+  const fresh = await h.selection()
+  const rows = [...desktopFixture(h.cold), { ...desktopFixture(SOURCE)[1], pid: 502, started: 'family worker' }]
+  const first = await executeMove([fresh.from], to, h.paths, { processes: rows, moveOnly: true })
+  assert.deepEqual(first.receipt.sessions.map(row => row.id), [firstId])
+  const finished = await finishHeld(h.paths, { processes: [] })
+  assert.equal(finished.file, first.file)
+  assert.equal(finished.ok, true)
+  assert.equal(finished.added, 4)
+  assert.equal(finished.receipt.sessions.length, 5)
+  assert.equal(finished.targetChanged, true)
+  assert.equal(finished.complete, true)
+})
+
+async function interruptTaskFamily(h, operation, stage) {
+  const hook = stage === 'record' ? 'link' : 'rename'
+  const destination = stage === 'record' ? path.join(h.dir('T'), `local_${h.notificationId ?? SOURCE}.json`) : stage === 'source' ? h.sourceFile : h.targetFile
+  const script = `
+    import fs from 'node:fs/promises'
+    import { syncBuiltinESMExports } from 'node:module'
+    import { accounts, executeMove, layout, undo } from './transplant.js'
+    const original = fs.${hook}
+    fs.${hook} = async (...args) => {
+      const result = await original(...args)
+      if (args[1] === ${JSON.stringify(destination)}) process.exit(23)
+      return result
+    }
+    syncBuiltinESMExports()
+    const paths = layout(${JSON.stringify(h.root)})
+    const all = await accounts(paths, [])
+    if (${JSON.stringify(operation)} === 'undo') await undo(paths, { processes: [] })
+    else await executeMove([all.find(row => row.account === ${JSON.stringify(h.acct.P)})], all.find(row => row.account === ${JSON.stringify(h.acct.T)}), paths, { processes: [] })
+  `
+  const result = await promisify(execFile)(process.execPath, ['--input-type=module', '-e', script], { cwd: here, env: { ...process.env, HOME: h.root } })
+    .then(() => 0, error => error.code)
+  assert.equal(result, 23)
+}
+
+test('task registry and record interruptions recover in the existing receipt', async () => {
+  for (const stage of ['source', 'record', 'target']) {
+    const h = await taskFamilyFixture(true)
+    await interruptTaskFamily(h, 'move', stage)
+    const result = await finishWorkflow(h.paths, { processes: [] })
+    assert.equal(result.recoveryRequired, true)
+    const files = (await readdir(h.paths.state)).filter(name => /^\d.*\.json$/.test(name))
+    assert.equal(files.length, 1)
+    const receipt = JSON.parse(await readFile(path.join(h.paths.state, files[0])))
+    assert.equal(receipt.finalizing, false)
+    assert.deepEqual(receipt.sessions.map(row => row.id), [h.cold])
+    assert.deepEqual(receipt.taskTransfers, [])
+    assert.deepEqual(JSON.parse(await readFile(h.sourceFile)), h.sourceRegistry)
+    assert.deepEqual(JSON.parse(await readFile(h.targetFile)), h.targetRegistry)
+    for (const sid of [SOURCE, h.run, h.second]) {
+      assert.ok(await readFile(path.join(h.dir('P'), `local_${sid}.json`)))
+      assert.equal(await stat(path.join(h.dir('T'), `local_${sid}.json`)).catch(() => null), null)
+    }
+    assert.ok((await undo(h.paths, { processes: [] })).dest)
+  }
+})
+
+test('CLI accounts exposes task recovery through Finish without selecting historical refusals', async () => {
+  const h = await taskFamilyFixture(true, 1)
+  await interruptTaskFamily(h, 'move', 'target')
+  const name = (await readdir(h.paths.state)).find(name => /^\d.*\.json$/.test(name)), file = path.join(h.paths.state, name)
+  const receipt = JSON.parse(await readFile(file))
+  assert.equal(receipt.finalizing, true)
+  assert.deepEqual(receipt.held, [])
+  assert.equal(receipt.taskTransfers.length, 1)
+  receipt.fromAccounts.push({ account: h.acct.Q, org: h.org.Q, label: 'Unrelated source' })
+  receipt.failed.push({ id: id(799), title: 'Historical refusal', error: 'scheduled task family member missing' })
+  await writeFile(file, JSON.stringify(receipt))
+  const before = await readFile(file)
+  const listed = await cli(h.root, ['accounts', '--json'])
+  assert.equal(listed.code, 0)
+  const pending = lines(listed.stdout)[0].filter(row => row.pending)
+  assert.equal(pending.length, 1)
+  assert.equal(pending[0].account, h.acct.P)
+  assert.equal(pending[0].org, h.org.P)
+  assert.equal(pending[0].pending, 'recovery')
+  assert.equal(pending[0].pendingAction, 'finish')
+  assert.equal(pending[0].receipt, file)
+  assert.deepEqual(pending[0].pendingFailures, [])
+  assert.deepEqual(await readFile(file), before)
+  let rows = [desktopFixture()[0]]
+  const calls = [], io = { inspect: () => rows, command: async name => {
+    calls.push(name)
+    rows = name.endsWith('osascript') ? [] : [{ ...desktopFixture()[0], pid: 700, desktopPid: 700, started: 'reopened' }]
+    return { status: 0 }
+  } }
+  const plan = await finishWorkflow(h.paths, { io })
+  assert.ok(plan.plan)
+  assert.equal(plan.plan.kind, 'recover')
+  assert.equal(plan.plan.receiptFile, file)
+  assert.deepEqual(calls, [])
+  const recovered = await finishWorkflow(h.paths, { io, approve: plan.plan.token })
+  assert.equal(recovered.restarted, true)
+  assert.equal(recovered.recoveryRequired, true)
+  assert.deepEqual(calls, ['/usr/bin/osascript', '/usr/bin/open'])
+  assert.deepEqual(JSON.parse(await readFile(h.sourceFile)), h.sourceRegistry)
+  assert.deepEqual(JSON.parse(await readFile(h.targetFile)), h.targetRegistry)
+  const again = lines((await cli(h.root, ['accounts', '--json'])).stdout)[0].filter(row => row.pending)
+  assert.deepEqual(again.map(row => [row.account, row.pending, row.pendingAction]), [[h.acct.P, 'local', 'finish']])
+  const finished = await finishWorkflow(h.paths, { processes: [] })
+  assert.equal(finished.file, file)
+  assert.equal(finished.ok, true)
+  assert.equal(finished.complete, true)
+  assert.equal(finished.receipt.sessions.length, 3)
+  assert.ok(finished.notMoved.some(row => row.title === 'Historical refusal'))
+  assert.ok(lines((await cli(h.root, ['accounts', '--json'])).stdout)[0].every(row => row.pending === null))
+})
+
+test('interrupted task Undo restores registrations and records together', async () => {
+  for (const stage of ['target', 'source']) {
+    const h = await taskFamilyFixture(true), { from, to } = await h.selection()
+    await executeMove([from], to, h.paths, { processes: [] })
+    await interruptTaskFamily(h, 'undo', stage)
+    const pending = lines((await cli(h.root, ['accounts', '--json'])).stdout)[0].filter(row => row.pending)
+    assert.deepEqual(pending.map(row => [row.pending, row.pendingAction]), [['undo', 'finish']])
+    const result = await finishWorkflow(h.paths, { processes: [] })
+    assert.ok(result.dest)
+    assert.deepEqual(JSON.parse(await readFile(h.sourceFile)), h.sourceRegistry)
+    assert.deepEqual(JSON.parse(await readFile(h.targetFile)), h.targetRegistry)
+  }
+})
+
+test('task edits and dependencies block Undo and interrupted recovery without overwriting registries', async () => {
+  for (const recovery of [false, true]) for (const change of ['task', 'dependency', 'skip', 'retry', 'skip removed', 'retry removed', 'retry added']) {
+    const h = await taskFamilyFixture(), { from, to } = await h.selection()
+    if (recovery) await interruptTaskFamily(h, 'move', 'target')
+    else await executeMove([from], to, h.paths, { processes: [] })
+    const before = JSON.parse(await readFile(h.targetFile)), changed = structuredClone(before)
+    if (change === 'task') changed.scheduledTasks.find(task => task.id === h.tasks[0].id).enabled = true
+    else if (change === 'dependency') changed.scheduledTasks.push({ id: 'new_task', notifySessionId: `local_${SOURCE}`, enabled: false })
+    else if (change === 'skip') changed.recordedSkips.task_0.reason = 'edited'
+    else if (change === 'retry') changed.runRetries.task_0.attempt++
+    else if (change === 'skip removed') delete changed.recordedSkips.task_0
+    else if (change === 'retry removed') delete changed.runRetries.task_0
+    else changed.runRetries.task_1 = { attempt: 1, retryAt: '2026-09-05T00:00:00Z' }
+    await writeFile(h.targetFile, JSON.stringify(changed))
+    const result = await (recovery ? finishWorkflow : undo)(h.paths, { processes: [] })
+    assert.match((result.reconciled?.problems ?? result.restoreProblems ?? result.changed).join(' '), /scheduled task/)
+    assert.deepEqual(JSON.parse(await readFile(h.targetFile)), changed)
+    assert.ok(await readFile(path.join(h.dir('T'), `local_${SOURCE}.json`)))
+    await writeFile(h.targetFile, JSON.stringify(before))
+    const retried = await (recovery ? finishWorkflow : undo)(h.paths, { processes: [] })
+    assert.ok(recovery ? retried.recoveryRequired : retried.dest)
+    assert.deepEqual(JSON.parse(await readFile(h.sourceFile)), h.sourceRegistry)
+  }
+})
+
+test('task transfer uses final registration state and preserves later unrelated registry edits', async () => {
+  const h = await taskFamilyFixture(), { from, to } = await h.selection()
+  const inv = await inventory([from], to, h.paths, () => {}, { processes: [] })
+  h.sourceRegistry.scheduledTasks[0].lastRunAt = '2026-09-02T00:00:00Z'
+  h.sourceRegistry.scheduledTasks[0].enabled = true
+  h.sourceRegistry.recordedSkips.task_0.reason = 'missed before transfer'
+  h.sourceRegistry.runRetries.task_0.attempt = 4
+  await writeFile(h.sourceFile, JSON.stringify(h.sourceRegistry))
+  let changed = false
+  const result = await move(inv, to, h.paths, (stage, text, extra) => {
+    if (stage !== 'move' || extra?.completed !== 1 || changed) return
+    const source = JSON.parse(readFileSync(h.sourceFile))
+    if (source.scheduledTasks.length) return
+    changed = true
+    for (const file of [h.sourceFile, h.targetFile]) writeFileSync(file, JSON.stringify({ ...JSON.parse(readFileSync(file)), futureDuringMove: { intact: true } }))
+  })
+  assert.equal(result.ok, true)
+  assert.equal(changed, true)
+  assert.equal(JSON.parse(await readFile(h.targetFile)).scheduledTasks.find(task => task.id === h.tasks[0].id).enabled, true)
+  assert.deepEqual(JSON.parse(await readFile(h.targetFile)).recordedSkips.task_0, h.sourceRegistry.recordedSkips.task_0)
+  assert.deepEqual(JSON.parse(await readFile(h.targetFile)).runRetries.task_0, h.sourceRegistry.runRetries.task_0)
+  for (const file of [h.sourceFile, h.targetFile]) await writeFile(file, JSON.stringify({ ...JSON.parse(await readFile(file)), futureDuringUndo: [1, 2] }))
+  assert.ok((await undo(h.paths, { processes: [] })).dest)
+  assert.deepEqual(JSON.parse(await readFile(h.sourceFile)), { ...h.sourceRegistry, futureDuringMove: { intact: true }, futureDuringUndo: [1, 2] })
+  assert.deepEqual(JSON.parse(await readFile(h.targetFile)), { ...h.targetRegistry, futureDuringMove: { intact: true }, futureDuringUndo: [1, 2] })
+})
+
+test('task families include parent and fork closure without merging matching history', async () => {
+  const h = await taskFamilyFixture(), parent = id(704), child = id(705)
+  await h.write(parent, [entry('user', 90, null, parent)])
+  await h.record('P', parent, rehomeRecord())
+  await h.record('P', SOURCE, rehomeRecord({ forkedFromSessionId: `local_${parent}` }))
+  await h.write(child, [entry('user', 91, null, child)])
+  await h.record('P', child, rehomeRecord({ forkedFromSessionId: `local_${SOURCE}`, isArchived: true }))
+  await h.record('Q', SOURCE, rehomeRecord())
+  const { from, to } = await h.selection()
+  const inv = await inventory([from], to, h.paths, () => {}, { processes: [] })
+  assert.equal(inv.move.filter(row => row.taskFamily).length, 5)
+  const result = await move(inv, to, h.paths)
+  assert.equal(result.ok, true)
+  assert.equal(result.receipt.sessions.length, 6)
+  assert.ok(await readFile(path.join(h.dir('Q'), `local_${SOURCE}.json`)))
+  assert.ok((await undo(h.paths, { processes: [] })).dest)
+})
+
+test('task moves, Undo and recovery use the approved restart and preserve final scheduler state', async () => {
+  for (const operation of ['move', 'undo', 'recovery']) {
+    const h = await taskFamilyFixture(), { from, to } = await h.selection()
+    if (operation === 'undo') await executeMove([from], to, h.paths, { processes: [] })
+    if (operation === 'recovery') await interruptTaskFamily(h, 'move', 'target')
+    let rows = [desktopFixture()[0]], time = 0
+    const calls = []
+    const io = { inspect: () => rows, now: () => time, command: async file => {
+      calls.push(file)
+      time += 100
+      if (file.endsWith('osascript')) {
+        if (operation === 'move') {
+          h.sourceRegistry.scheduledTasks[0].lastScheduledFor = '2026-09-03T00:00:00Z'
+          h.sourceRegistry.scheduledTasks[0].enabled = true
+          await writeFile(h.sourceFile, JSON.stringify(h.sourceRegistry))
+        }
+        rows = []
+      } else rows = [{ ...desktopFixture()[0], pid: 700, desktopPid: 700, started: 'reopened' }]
+      return { status: 0 }
+    } }
+    const run = options => operation === 'move' ? executeMove([from], to, h.paths, options) : operation === 'undo' ? undo(h.paths, options) : finishWorkflow(h.paths, options)
+    const plan = await run({ io })
+    assert.ok(plan.plan, operation)
+    assert.deepEqual(calls, [])
+    const result = await run({ io, approve: plan.plan.token })
+    assert.equal(result.restarted, true, JSON.stringify({ operation, reason: result.reason, outcome: result.restartOutcome?.outcome }))
+    assert.deepEqual(calls, ['/usr/bin/osascript', '/usr/bin/open'])
+    assert.ok(time < 30000)
+    if (operation === 'move') {
+      assert.equal(result.ok, true)
+      assert.deepEqual(JSON.parse(await readFile(h.targetFile)).scheduledTasks.slice(1), h.sourceRegistry.scheduledTasks)
+    } else {
+      assert.ok(operation === 'undo' ? result.dest : result.recoveryRequired)
+      assert.deepEqual(JSON.parse(await readFile(h.sourceFile)), h.sourceRegistry)
+    }
+  }
+})
+
+test('task workers and changed restart inventories never authorize an external stop', async () => {
+  const h = await taskFamilyFixture(), { from, to } = await h.selection()
+  const table = [...desktopFixture(), { pid: 600, worker: true, ids: [h.run], desktopPid: null }]
+  const result = await executeMove([from], to, h.paths, { processes: table })
+  assert.equal(result.plan, undefined)
+  assert.deepEqual(result.receipt.sessions.map(row => row.id), [h.cold])
+  assert.deepEqual(JSON.parse(await readFile(h.sourceFile)), h.sourceRegistry)
+  const calls = []
+  let rows = [desktopFixture()[0]]
+  const io = { inspect: () => rows, command: async file => { calls.push(file); return { status: 0 } } }
+  const planned = await finishWorkflow(h.paths, { io })
+  assert.ok(planned.plan)
+  rows = [...rows, { ...desktopFixture(h.run)[1], pid: 701 }]
+  const stale = await finishWorkflow(h.paths, { io, approve: planned.plan.token })
+  assert.equal(stale.ok, false)
+  assert.deepEqual(calls, [])
+})
+
+test('task restart deadline preserves held families after completed ordinary work', async () => {
+  const h = await taskFamilyFixture(), { from, to } = await h.selection()
+  let rows = [desktopFixture()[0]], time = 0
+  const io = { inspect: () => rows, now: () => time, command: async file => {
+    rows = file.endsWith('osascript') ? [] : [{ ...desktopFixture()[0], pid: 700, desktopPid: 700, started: 'reopened' }]
+    return { status: 0 }
+  } }
+  const planned = await executeMove([from], to, h.paths, { io })
+  const original = fs.rename
+  fs.rename = async (...args) => {
+    const result = await original(...args)
+    if (path.dirname(args[1]) === h.paths.state && /^\d.*\.json$/.test(path.basename(args[1]))) {
+      const receipt = JSON.parse(await readFile(args[1]))
+      if (receipt.finalizing === false && receipt.sessions.length === 1) time = 23000
+    }
+    return result
+  }
+  syncBuiltinESMExports()
+  let result
+  try { result = await executeMove([from], to, h.paths, { io, approve: planned.plan.token }) }
+  finally { fs.rename = original; syncBuiltinESMExports() }
+  assert.equal(result.ok, false)
+  assert.equal(result.restarted, true)
+  assert.deepEqual(JSON.parse(await readFile(h.sourceFile)), h.sourceRegistry)
+  const receipts = (await readdir(h.paths.state)).filter(name => /^\d.*\.json$/.test(name))
+  const receipt = JSON.parse(await readFile(path.join(h.paths.state, receipts[0])))
+  assert.deepEqual(receipt.sessions.map(row => row.id), [h.cold])
+  assert.equal(receipt.held.flatMap(row => row.sources).length, 3)
+  const finished = await finishHeld(h.paths, { processes: [] })
+  assert.equal(finished.ok, true)
+  assert.equal(finished.receipt.sessions.length, 4)
+})
+
+test('a failed task-family placement rolls back the family and keeps ordinary moves', async () => {
+  const h = await taskFamilyFixture(true), { from, to } = await h.selection()
+  const original = fs.link
+  let failed = false
+  fs.link = async (...args) => {
+    if (!failed && args[1] === path.join(h.dir('T'), `local_${SOURCE}.json`)) { failed = true; throw new Error('fixture publication failure') }
+    return original(...args)
+  }
+  syncBuiltinESMExports()
+  let result
+  try { result = await executeMove([from], to, h.paths, { processes: [] }) }
+  finally { fs.link = original; syncBuiltinESMExports() }
+  assert.equal(result.ok, false)
+  assert.deepEqual(result.receipt.sessions.map(row => row.id), [h.cold])
+  assert.deepEqual(JSON.parse(await readFile(h.sourceFile)), h.sourceRegistry)
+  assert.deepEqual(JSON.parse(await readFile(h.targetFile)), h.targetRegistry)
+  assert.equal((await finishHeld(h.paths, { processes: [] })).receipt.sessions.length, 4)
+})
+
+test('registry changes during a task move remain recoverable without lost edits', async () => {
+  const h = await taskFamilyFixture(), { from, to } = await h.selection()
+  let edited = false
+  const result = await executeMove([from], to, h.paths, { processes: [], report: (stage, text, extra) => {
+    if (stage !== 'move' || extra?.completed !== 1 || edited) return
+    const source = JSON.parse(readFileSync(h.sourceFile))
+    if (source.scheduledTasks.length) return
+    edited = true
+    source.scheduledTasks = [{ ...h.tasks[0], enabled: true }]
+    source.unrelatedEdit = 9
+    writeFileSync(h.sourceFile, JSON.stringify(source))
+  } })
+  assert.equal(edited, true)
+  assert.equal(result.recoveryRequired, true)
+  const changed = JSON.parse(await readFile(h.sourceFile))
+  assert.equal(changed.scheduledTasks[0].enabled, true)
+  assert.equal(changed.unrelatedEdit, 9)
+  changed.scheduledTasks = []
+  await writeFile(h.sourceFile, JSON.stringify(changed))
+  await finishWorkflow(h.paths, { processes: [] })
+  assert.deepEqual(JSON.parse(await readFile(h.sourceFile)), { ...h.sourceRegistry, unrelatedEdit: 9 })
+  assert.ok(await readFile(path.join(h.dir('T'), `local_${h.cold}.json`)))
+})
+
+test('Keep local validates target identity and recovery even when only held work remains', async () => {
+  for (const change of ['sessionId', 'cliSessionId', 'cwd', 'missing transcript', 'missing record']) {
+    const h = await home()
+    await h.write(SOURCE, [entry('user', 1, null, SOURCE)])
+    await h.record('P', SOURCE, rehomeRecord())
+    await h.write(id(710), [entry('user', 2, null, id(710))])
+    await h.record('P', id(710), rehomeRecord())
+    const all = await accounts(h.paths), from = all.find(row => row.account === h.acct.P), to = all.find(row => row.account === h.acct.T)
+    const moved = await executeMove([from], to, h.paths, { processes: desktopFixture(id(710)), moveOnly: true })
+    const row = moved.receipt.sessions[0]
+    if (change === 'missing transcript') await unlink(row.targetTranscript)
+    else if (change === 'missing record') await unlink(row.record)
+    else await writeFile(row.record, JSON.stringify({ ...JSON.parse(await readFile(row.record)), [change]: change === 'sessionId' ? `local_${id(711)}` : change === 'cliSessionId' ? id(711) : '/tmp/changed' }))
+    const kept = await keepLocal(h.paths)
+    assert.ok(kept.refused.length, change)
+    assert.equal(kept.receipt.held.length, 1)
+  }
+})
+
+test('Finish of held local work treats an earlier refusal as information', async () => {
+  const h = await home(), cold = id(712)
+  for (const [index, sid] of [SOURCE, cold].entries()) {
+    await h.write(sid, [entry('user', index + 1, null, sid)])
+    await h.record('P', sid, rehomeRecord())
+  }
+  const all = await accounts(h.paths), from = all.find(row => row.account === h.acct.P), to = all.find(row => row.account === h.acct.T)
+  const first = await executeMove([from], to, h.paths, { processes: desktopFixture(), moveOnly: true })
+  first.receipt.failed.push({ id: id(713), title: 'Earlier refusal', error: 'scheduled task family member missing' })
+  await writeFile(first.file, JSON.stringify(first.receipt))
+  const finished = await finishWorkflow(h.paths, { processes: [] })
+  assert.equal(finished.ok, true)
+  assert.equal(finished.complete, true)
+  assert.deepEqual(finished.failed, [])
+  assert.equal(finished.notMoved.length, 1)
+})
+
+test('task scheduler safety uses the exact organization and rechecks account switches', async () => {
+  for (const switching of [false, true]) {
+    const h = await taskFamilyFixture(), f = await identityFixture(h)
+    await f.write(f.init(1, h.acct.P, h.org.Q))
+    const { from, to } = await h.selection()
+    let switched = false
+    const result = await executeMove([from], to, h.paths, { processes: f.processes, report: (stage, text, extra) => {
+      if (!switching || switched || stage !== 'move' || extra?.completed !== 1 || JSON.parse(readFileSync(h.sourceFile)).scheduledTasks.length) return
+      switched = true
+      writeFileSync(path.join(h.paths.logs, 'main.log'), f.event(2, '[LocalSessionManager] Org changed'))
+    } })
+    if (!switching) assert.equal(result.receipt.sessions.length, 4)
+    else {
+      assert.equal(switched, true)
+      assert.equal(result.recoveryRequired, true)
+      assert.deepEqual(JSON.parse(await readFile(h.targetFile)), h.targetRegistry)
+      const swept = await sweep(h.paths, { processes: f.processes })
+      assert.equal(swept.ok, false)
+      assert.match(swept.error, /scheduler requires/)
+      await finishWorkflow(h.paths, { processes: [] })
+      assert.deepEqual(JSON.parse(await readFile(h.sourceFile)), h.sourceRegistry)
+    }
+  }
+})
+
+test('task Undo preserves absent registries and registries without a task array', async () => {
+  for (const registry of [null, { future: { intact: true } }]) {
+    const h = await taskFamilyFixture()
+    if (registry) await writeFile(h.targetFile, JSON.stringify(registry))
+    else await unlink(h.targetFile)
+    const { from, to } = await h.selection()
+    const result = await executeMove([from], to, h.paths, { processes: [] })
+    assert.equal(result.ok, true)
+    assert.ok((await undo(h.paths, { processes: [] })).dest)
+    assert.deepEqual(await readFile(h.targetFile).then(JSON.parse, () => null), registry)
+  }
+})
+
+test('task notification identities may differ from CLI ids and remain protected during recovery', async () => {
+  const h = await taskFamilyFixture()
+  h.notificationId = id(714)
+  await h.record('P', SOURCE, rehomeRecord({ sessionId: `local_${h.notificationId}` }))
+  await rename(path.join(h.dir('P'), `local_${SOURCE}.json`), path.join(h.dir('P'), `local_${h.notificationId}.json`))
+  for (const task of h.tasks) task.notifySessionId = `local_${h.notificationId}`
+  for (const [index, sid] of [h.run, h.second].entries()) await h.record('P', sid, rehomeRecord({ scheduledTaskId: h.tasks[index].id, notifySessionId: `local_${h.notificationId}` }))
+  await writeFile(h.sourceFile, JSON.stringify(h.sourceRegistry))
+  await interruptTaskFamily(h, 'move', 'record')
+  const file = path.join(h.dir('T'), `local_${h.notificationId}.json`), before = await readFile(file)
+  await writeFile(file, JSON.stringify({ ...JSON.parse(before), title: 'Changed after interruption' }))
+  const refused = await finishWorkflow(h.paths, { processes: [] })
+  assert.equal(refused.recoveryRequired, true)
+  assert.match(refused.reconciled.error, /task.*record changed/)
+  await writeFile(file, before)
+  await finishWorkflow(h.paths, { processes: [] })
+  const finished = await finishHeld(h.paths, { processes: [] })
+  assert.equal(finished.ok, true)
+  assert.equal(JSON.parse(await readFile(file)).sessionId, `local_${h.notificationId}`)
+  assert.ok((await undo(h.paths, { processes: [] })).dest)
+  assert.deepEqual(JSON.parse(await readFile(h.sourceFile)), h.sourceRegistry)
+})
+
+test('task registry edits during publication and Undo retain their values and recovery', async () => {
+  for (const phase of ['publication', 'undo']) {
+    const h = await taskFamilyFixture(), { from, to } = await h.selection()
+    if (phase === 'undo') await executeMove([from], to, h.paths, { processes: [] })
+    const hook = phase === 'publication' ? 'writeFile' : 'rename', original = fs[hook]
+    let injected = false
+    fs[hook] = async (...args) => {
+      const result = await original(...args)
+      const matches = phase === 'publication' ? String(args[0]).startsWith(h.targetFile + '.') : args[0] === path.join(h.dir('T'), `local_${SOURCE}.json`)
+      if (matches && !injected) {
+        injected = true
+        const registry = JSON.parse(await readFile(h.targetFile))
+        registry.duringWrite = { preserved: true }
+        if (phase === 'undo') registry.scheduledTasks.push({ ...h.tasks[0], enabled: true })
+        await originalWrite(h.targetFile, JSON.stringify(registry))
+      }
+      return result
+    }
+    const originalWrite = phase === 'publication' ? original : fs.writeFile
+    syncBuiltinESMExports()
+    let result
+    try { result = phase === 'publication' ? await executeMove([from], to, h.paths, { processes: [] }) : await undo(h.paths, { processes: [] }) }
+    finally { fs[hook] = original; syncBuiltinESMExports() }
+    assert.equal(injected, true)
+    assert.deepEqual(JSON.parse(await readFile(h.targetFile)).duringWrite, { preserved: true })
+    if (phase === 'publication') {
+      assert.equal(result.ok, false)
+      assert.deepEqual(result.receipt.sessions.map(row => row.id), [h.cold])
+      assert.equal((await finishHeld(h.paths, { processes: [] })).ok, true)
+      assert.ok((await undo(h.paths, { processes: [] })).dest)
+    } else {
+      assert.match(result.restoreProblems.join(' '), /scheduled task/)
+      const registry = JSON.parse(await readFile(h.targetFile))
+      assert.equal(registry.scheduledTasks.find(task => task.id === h.tasks[0].id).enabled, true)
+      registry.scheduledTasks = registry.scheduledTasks.filter(task => !h.tasks.some(owned => owned.id === task.id))
+      await writeFile(h.targetFile, JSON.stringify(registry))
+      assert.ok((await finishWorkflow(h.paths, { processes: [] })).dest)
+    }
+    assert.deepEqual(JSON.parse(await readFile(h.sourceFile)), h.sourceRegistry)
+    assert.deepEqual(JSON.parse(await readFile(h.targetFile)), { ...h.targetRegistry, duringWrite: { preserved: true } })
+  }
+})
+
+test('a late destination alias cannot take a task family through an id collision', async () => {
+  const h = await taskFamilyFixture(), { from, to } = await h.selection(), alias = id(715)
+  const inv = await inventory([from], to, h.paths, () => {}, { processes: [] })
+  await h.record('T', SOURCE, rehomeRecord({ sessionId: `local_${alias}` }))
+  await rename(path.join(h.dir('T'), `local_${SOURCE}.json`), path.join(h.dir('T'), `local_${alias}.json`))
+  const result = await move(inv, to, h.paths)
+  assert.equal(result.ok, false)
+  assert.deepEqual(result.receipt.sessions.map(row => row.id), [h.cold])
+  assert.deepEqual(JSON.parse(await readFile(h.sourceFile)), h.sourceRegistry)
+  assert.match(result.receipt.failed.at(-1).error, /session id collision/)
+})
+
 test('rehome eligibility stays narrow around ownership locks', async () => {
   const h = await home()
   await h.write(SOURCE, [entry('user', 1, null, SOURCE), entry('assistant', 2, 1, SOURCE)])
@@ -3704,7 +4501,9 @@ test('unreadable Desktop metadata stops retirement and preserves recoverable sou
     assert.deepEqual(await readFile(file), bytes)
     assert.equal(JSON.parse(await readFile(path.join(h.dir('T'), path.basename(file)))).sessionId, JSON.parse(bytes).sessionId)
   }
-  assert.equal((await sweep(h.paths, { processes: [] })).complete, false)
+  const swept = await sweep(h.paths, { processes: [] })
+  assert.equal(swept.complete, true)
+  assert.match(swept.verification.notMoved.at(-1).error, /unreadable Desktop record/)
   await unlink(corruptFile)
   assert.ok((await undo(h.paths)).dest)
   for (const [file, bytes] of originals) assert.deepEqual(await readFile(file), bytes)
@@ -4646,6 +5445,10 @@ test('process registry identifies a new worker without argv ids and rejects stal
 
 test('Swift preserves command, progress, metadata, and completion states', async () => {
   const root = await mkdtemp(path.join(os.tmpdir(), 'ct-swift-state-'))
+  const h = await taskFamilyFixture(true, 1)
+  await interruptTaskFamily(h, 'move', 'target')
+  const recoveryAccounts = await cli(h.root, ['accounts', '--json'])
+  assert.equal(recoveryAccounts.code, 0)
   let source = (await readFile(path.join(here, 'menubar.swift'), 'utf8')).split('@main\nstruct TransplantApp: App {')[0]
   const start = source.indexOf('    private func run(_ args: [String]')
   const end = source.indexOf('\nstruct RowKey: PreferenceKey', start)
@@ -4819,6 +5622,17 @@ struct StateChecks {
             }), encoding: .utf8)!
         }
         requests = []
+        let taskRecovery = Model(demo: try! JSONDecoder().decode([Account].self, from: Data(base64Encoded: "TASK_RECOVERY_ACCOUNTS")!))
+        precondition(taskRecovery.pendingReady && !taskRecovery.ready && !taskRecovery.canKeepLocal)
+        precondition(taskRecovery.pendingButtonTitle == "Finish move")
+        precondition(taskRecovery.pendingPrompt == "Finish the interrupted move")
+        taskRecovery.skipRestartWarning = true
+        taskRecovery.finishPending()
+        precondition(requests[0].0 == ["finish", "--json"])
+        requests[0].1(#"{"plan":true,"kind":"recover","token":"task-recovery-token","affected":[]}"#)
+        requests[0].2(0, "")
+        precondition(requests[1].0 == ["finish", "--json", "--restart-approved", "task-recovery-token"])
+        requests = []
         let recovering = Model(demo: try! JSONDecoder().decode([Account].self, from: Data(accountResponse(true).utf8)))
         recovering.finishPending()
         precondition(requests[0].0 == ["finish", "--json"])
@@ -4902,10 +5716,23 @@ struct StateChecks {
         requests[1].2(0, "")
         precondition(failed.note == "1 need attention")
         precondition(failed.lines.contains { $0.1.contains("conflicting history") })
+        requests = []
+        let completedCloud = Model(demo: try! JSONDecoder().decode([Account].self, from: Data(accountResponse(true).utf8)))
+        completedCloud.finishPending()
+        requests[0].1(#"{"done":true,"ok":true,"complete":true,"moved":1,"failed":[],"notMoved":[{"id":"fixture","title":"Earlier refusal","error":"task family missing"}]}"#)
+        requests[0].2(0, "")
+        requests[1].1(accountResponse(false))
+        requests[1].2(0, "")
+        precondition(!completedCloud.note.contains("attention"))
+        precondition(completedCloud.lines.contains { $0.0 == "not moved" && $0.1.contains("task family missing") })
+        let recoveredCloud = failedFinishModel()
+        sweepReply(recoveredCloud, #"{"swept":true,"ok":true,"complete":true,"receipt":"receipt-one","failed":[],"notMoved":[{"id":"fixture","error":"task family missing"}]}"#)
+        precondition(recoveredCloud.note == "No remaining work")
         print("Swift queue and metadata states passed")
     }
 }
 `
+  source = source.replace('TASK_RECOVERY_ACCOUNTS', Buffer.from(recoveryAccounts.stdout.trim()).toString('base64'))
   const file = path.join(root, 'checks.swift'), binary = path.join(root, 'checks')
   await writeFile(file, source)
   await promisify(execFile)('/usr/bin/swiftc', ['-parse-as-library', '-o', binary, file], { timeout: 90_000 })


### PR DESCRIPTION
Move scheduled reminders with their linked conversations in one recoverable operation. Keep completed tolerates normal Desktop metadata updates, and Finish treats earlier refusals as information.

Version 4.0.6 also tolerates an already-absent registry during rollback, rejects empty restart approvals before mutation, and prevents stale authentication errors from blocking completed moves. Repeated fixtures are consolidated without removing recovery checks.

Validation: all 249 tests, Swift state checks and packaged CLI checks passed on the final revision. A real installed-menubar move and Undo passed, and Desktop ran the transferred reminder under Personal using Haiku. Tested on macOS 27.0, Claude Desktop 1.52386.3 and Claude Code 2.1.266.
